### PR TITLE
Fix session detection

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -102,48 +102,36 @@ jobs:
 
           mkdir -p pkg/usr/bin
           mkdir -p pkg/etc/screenshooter-mcp
-          mkdir -p pkg/lib/systemd/system
+          mkdir -p pkg/usr/lib/systemd/user
           mkdir -p control
 
           cp screenshooter-mcp pkg/usr/bin/screenshooter-mcp-server
           echo '{"log_level":"info","color":"auto","listen":"127.0.0.1:11777"}' > pkg/etc/screenshooter-mcp/config.json
-          cat > pkg/lib/systemd/system/screenshooter-mcp.service << 'SYSTEMD'
+          cat > pkg/usr/lib/systemd/user/screenshooter-mcp.service << 'SYSTEMD'
           [Unit]
           Description=Screenshooter MCP Server
-          After=network.target
+          PartOf=graphical-session.target
+          After=graphical-session.target
 
           [Service]
           Type=simple
           ExecStart=/usr/bin/screenshooter-mcp-server --listen 127.0.0.1:11777
           Restart=on-failure
-          User=screenshooter-mcp
-          Group=screenshooter-mcp
 
           [Install]
-          WantedBy=multi-user.target
+          WantedBy=graphical-session.target
           SYSTEMD
 
           cat > control/postinst << 'POSTINST'
           #!/bin/sh
-          deb-systemd-helper stop screenshooter-mcp 2>/dev/null || true
-          if ! id -u screenshooter-mcp >/dev/null 2>&1; then
-            useradd -r -s /sbin/nologin screenshooter-mcp
-          fi
-          systemctl daemon-reload || true
-          deb-systemd-helper unmask screenshooter-mcp || true
-          deb-systemd-helper purge screenshooter-mcp || true
-          deb-systemd-helper enable screenshooter-mcp || true
-          deb-systemd-helper restart screenshooter-mcp || true
+          set -e
+          for uid in $(loginctl list-users --no-legend 2>/dev/null | awk '{print $1}'); do
+            if [ -d "/run/user/$uid" ]; then
+              su - "$(id -nu "$uid")" -c "systemctl --user daemon-reload" 2>/dev/null || true
+            fi
+          done
           POSTINST
-
-          cat > control/prerm << 'PRERM'
-          #!/bin/sh
-          deb-systemd-helper stop screenshooter-mcp 2>/dev/null || true
-          if id -u screenshooter-mcp >/dev/null 2>&1; then
-            deluser --system screenshooter-mcp
-            delgroup --system --only-if-empty screenshooter-mcp 
-          fi
-          PRERM
+          chmod 755 control/postinst
 
           fpm -s dir -t deb \
             -C pkg \
@@ -156,8 +144,7 @@ jobs:
             --license MIT \
             --vendor "Emmanuel Deloget" \
             --depends systemd \
-            --after-install control/postinst \
-            --before-remove control/prerm
+            --after-install control/postinst
 
       - name: Create stdio package
         run: |
@@ -225,47 +212,36 @@ jobs:
 
           mkdir -p pkg/usr/bin
           mkdir -p pkg/etc/screenshooter-mcp
-          mkdir -p pkg/usr/lib/systemd/system
-          mkdir control
+          mkdir -p pkg/usr/lib/systemd/user
+          mkdir -p control
 
           cp screenshooter-mcp pkg/usr/bin/screenshooter-mcp-server
           echo '{"log_level":"info","color":"auto","listen":"127.0.0.1:11777"}' > pkg/etc/screenshooter-mcp/config.json
-          cat > pkg/usr/lib/systemd/system/screenshooter-mcp.service << 'SYSTEMD'
+          cat > pkg/usr/lib/systemd/user/screenshooter-mcp.service << 'SYSTEMD'
           [Unit]
           Description=Screenshooter MCP Server
-          After=network.target
+          PartOf=graphical-session.target
+          After=graphical-session.target
 
           [Service]
           Type=simple
           ExecStart=/usr/bin/screenshooter-mcp-server --listen 127.0.0.1:11777
           Restart=on-failure
-          User=screenshooter-mcp
-          Group=screenshooter-mcp
 
           [Install]
-          WantedBy=multi-user.target
+          WantedBy=graphical-session.target
           SYSTEMD
 
           cat > control/postinst << 'POSTINST'
           #!/bin/sh
-          systemctl stop screenshooter-mcp 2>/dev/null || true
-          if ! id -u screenshooter-mcp >/dev/null 2>&1; then
-            useradd -r -s /sbin/nologin screenshooter-mcp
-          fi
-          systemctl daemon-reload || true
-          systemctl unmask screenshooter-mcp || true
-          systemctl purge screenshooter-mcp || true
-          systemctl enable screenshooter-mcp || true
-          systemctl restart screenshooter-mcp || true
+          set -e
+          for uid in $(loginctl list-users --no-legend 2>/dev/null | awk '{print $1}'); do
+            if [ -d "/run/user/$uid" ]; then
+              su - "$(id -nu "$uid")" -c "systemctl --user daemon-reload" 2>/dev/null || true
+            fi
+          done
           POSTINST
-
-          cat > control/prerm << 'PRERM'
-          #!/bin/sh
-          systemctl stop screenshooter-mcp 2>/dev/null || true
-          if id -u screenshooter-mcp >/dev/null 2>&1; then
-            userdel screenshooter-mcp
-          fi
-          PRERM
+          chmod 755 control/postinst
 
           fpm -s dir -t rpm \
             -C pkg \
@@ -277,8 +253,7 @@ jobs:
             --url "https://github.com/emmanuel-deloget/screenshooter-mcp" \
             --license MIT \
             --vendor "Emmanuel Deloget" \
-            --after-install control/postinst \
-            --before-remove control/prerm
+            --after-install control/postinst
 
       - name: Create stdio package
         run: |

--- a/internal/capture/environment.go
+++ b/internal/capture/environment.go
@@ -9,8 +9,11 @@
 package capture
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 )
 
 // Environment represents the detected desktop environment.
@@ -36,19 +39,95 @@ const (
 	EnvironmentUnknown Environment = "unknown"
 )
 
+// commandExecutor is an interface for executing commands, used for testing.
+type commandExecutor interface {
+	LookPath(file string) (string, error)
+	Run(name string, args ...string) ([]byte, error)
+}
+
+// realExecutor implements commandExecutor using os/exec.
+type realExecutor struct{}
+
+func (r *realExecutor) LookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+func (r *realExecutor) Run(name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	return stdout.Bytes(), err
+}
+
 // EnvironmentDetector detects the current desktop environment.
 //
 // EnvironmentDetector provides functionality to identify whether the system
 // is running X11 or Wayland. This is used to select the appropriate
 // capture implementation for the current session.
-type EnvironmentDetector struct{}
+type EnvironmentDetector struct {
+	executor commandExecutor
+}
 
 // NewEnvironmentDetector creates a new EnvironmentDetector.
 //
 // No initialization is required - the detector is stateless and
 // can be created with the default values.
 func NewEnvironmentDetector() *EnvironmentDetector {
-	return &EnvironmentDetector{}
+	return &EnvironmentDetector{
+		executor: &realExecutor{},
+	}
+}
+
+// detectViaLoginctl queries systemd-logind for active sessions to determine
+// the desktop environment type. This is useful when running as a system service
+// that doesn't have access to session environment variables.
+//
+// The function lists all sessions via loginctl, then checks the Type property
+// of each active session. It returns the first active session's type.
+//
+// Returns:
+//   - EnvironmentX11: Active X11 session found
+//   - EnvironmentWayland: Active Wayland session found
+//   - EnvironmentUnknown: No active graphical session or loginctl unavailable
+//
+// Returns an error if loginctl execution fails or session parsing encounters issues.
+func (d *EnvironmentDetector) detectViaLoginctl() (Environment, error) {
+	loginctl, err := d.executor.LookPath("loginctl")
+	if err != nil {
+		return EnvironmentUnknown, fmt.Errorf("loginctl not found: %w", err)
+	}
+
+	sessionsOutput, err := d.executor.Run(loginctl, "--no-legend", "list-sessions")
+	if err != nil {
+		return EnvironmentUnknown, fmt.Errorf("failed to list sessions: %w", err)
+	}
+
+	sessions := strings.Fields(string(sessionsOutput))
+	if len(sessions) == 0 {
+		return EnvironmentUnknown, fmt.Errorf("no sessions found")
+	}
+
+	for _, sessionID := range sessions {
+		typeOutput, err := d.executor.Run(loginctl, "show-session", sessionID, "-p", "State", "-p", "Type")
+		if err != nil {
+			continue
+		}
+
+		properties := string(typeOutput)
+		if !strings.Contains(properties, "State=active") {
+			continue
+		}
+
+		if strings.Contains(properties, "Type=x11") {
+			return EnvironmentX11, nil
+		}
+		if strings.Contains(properties, "Type=wayland") {
+			return EnvironmentWayland, nil
+		}
+	}
+
+	return EnvironmentUnknown, fmt.Errorf("no active graphical session found")
 }
 
 // Detect determines the current desktop environment.
@@ -64,9 +143,9 @@ func NewEnvironmentDetector() *EnvironmentDetector {
 //     If XDG_SESSION_TYPE is not set, the function checks for DISPLAY
 //     (X11) or WAYLAND_DISPLAY (Wayland) environment variables.
 //
-// The function requires BOTH the session type AND the display variable
-// to be present for a positive match. This prevents false positives
-// when environment variables are set but not actually in use.
+//  3. Final fallback: loginctl
+//     If no environment variables are set, queries systemd-logind for
+//     active sessions to determine the session type.
 //
 // Returns:
 //   - EnvironmentX11: X11 detected
@@ -97,5 +176,10 @@ func (d *EnvironmentDetector) Detect() (Environment, error) {
 		return EnvironmentWayland, nil
 	}
 
-	return EnvironmentUnknown, fmt.Errorf("could not detect desktop environment (no DISPLAY or WAYLAND_DISPLAY set)")
+	env, err := d.detectViaLoginctl()
+	if err == nil && env != EnvironmentUnknown {
+		return env, nil
+	}
+
+	return EnvironmentUnknown, fmt.Errorf("could not detect desktop environment (no DISPLAY or WAYLAND_DISPLAY set, loginctl fallback failed: %v)", err)
 }

--- a/internal/capture/environment_test.go
+++ b/internal/capture/environment_test.go
@@ -1,8 +1,162 @@
 package capture
 
 import (
+	"fmt"
 	"testing"
 )
+
+type mockExecutor struct {
+	lookPathFunc func(file string) (string, error)
+	runFunc      func(name string, args ...string) ([]byte, error)
+}
+
+func (m *mockExecutor) LookPath(file string) (string, error) {
+	return m.lookPathFunc(file)
+}
+
+func (m *mockExecutor) Run(name string, args ...string) ([]byte, error) {
+	return m.runFunc(name, args...)
+}
+
+func TestDetectViaLoginctl(t *testing.T) {
+	tests := []struct {
+		name        string
+		lookPath    func(file string) (string, error)
+		run         func(name string, args ...string) ([]byte, error)
+		expectedEnv Environment
+		expectError bool
+	}{
+		{
+			name: "loginctl not found",
+			lookPath: func(file string) (string, error) {
+				return "", fmt.Errorf("not found")
+			},
+			run:         nil,
+			expectedEnv: EnvironmentUnknown,
+			expectError: true,
+		},
+		{
+			name: "list sessions fails",
+			lookPath: func(file string) (string, error) {
+				return "/usr/bin/loginctl", nil
+			},
+			run: func(name string, args ...string) ([]byte, error) {
+				if len(args) >= 2 && args[0] == "--no-legend" && args[1] == "list-sessions" {
+					return nil, fmt.Errorf("failed")
+				}
+				return nil, nil
+			},
+			expectedEnv: EnvironmentUnknown,
+			expectError: true,
+		},
+		{
+			name: "no sessions",
+			lookPath: func(file string) (string, error) {
+				return "/usr/bin/loginctl", nil
+			},
+			run: func(name string, args ...string) ([]byte, error) {
+				if len(args) >= 2 && args[0] == "--no-legend" && args[1] == "list-sessions" {
+					return []byte(""), nil
+				}
+				return nil, nil
+			},
+			expectedEnv: EnvironmentUnknown,
+			expectError: true,
+		},
+		{
+			name: "active X11 session",
+			lookPath: func(file string) (string, error) {
+				return "/usr/bin/loginctl", nil
+			},
+			run: func(name string, args ...string) ([]byte, error) {
+				if len(args) >= 2 && args[0] == "--no-legend" && args[1] == "list-sessions" {
+					return []byte("1 seat0 user"), nil
+				}
+				if len(args) >= 4 && args[0] == "show-session" && args[1] == "1" {
+					return []byte("State=active\nType=x11\n"), nil
+				}
+				return nil, nil
+			},
+			expectedEnv: EnvironmentX11,
+			expectError: false,
+		},
+		{
+			name: "active Wayland session",
+			lookPath: func(file string) (string, error) {
+				return "/usr/bin/loginctl", nil
+			},
+			run: func(name string, args ...string) ([]byte, error) {
+				if len(args) >= 2 && args[0] == "--no-legend" && args[1] == "list-sessions" {
+					return []byte("2 seat0 user"), nil
+				}
+				if len(args) >= 4 && args[0] == "show-session" && args[1] == "2" {
+					return []byte("State=active\nType=wayland\n"), nil
+				}
+				return nil, nil
+			},
+			expectedEnv: EnvironmentWayland,
+			expectError: false,
+		},
+		{
+			name: "skip inactive session",
+			lookPath: func(file string) (string, error) {
+				return "/usr/bin/loginctl", nil
+			},
+			run: func(name string, args ...string) ([]byte, error) {
+				if len(args) >= 2 && args[0] == "--no-legend" && args[1] == "list-sessions" {
+					return []byte("1 seat0 user 2 seat0 user"), nil
+				}
+				if len(args) >= 4 && args[0] == "show-session" {
+					if args[1] == "1" {
+						return []byte("State=closing\nType=x11\n"), nil
+					}
+					if args[1] == "2" {
+						return []byte("State=active\nType=wayland\n"), nil
+					}
+				}
+				return nil, nil
+			},
+			expectedEnv: EnvironmentWayland,
+			expectError: false,
+		},
+		{
+			name: "no graphical sessions",
+			lookPath: func(file string) (string, error) {
+				return "/usr/bin/loginctl", nil
+			},
+			run: func(name string, args ...string) ([]byte, error) {
+				if len(args) >= 2 && args[0] == "--no-legend" && args[1] == "list-sessions" {
+					return []byte("1 seat0 user"), nil
+				}
+				if len(args) >= 4 && args[0] == "show-session" && args[1] == "1" {
+					return []byte("State=active\nType=tty\n"), nil
+				}
+				return nil, nil
+			},
+			expectedEnv: EnvironmentUnknown,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := &EnvironmentDetector{
+				executor: &mockExecutor{
+					lookPathFunc: tt.lookPath,
+					runFunc:      tt.run,
+				},
+			}
+
+			env, err := detector.detectViaLoginctl()
+			if env != tt.expectedEnv {
+				t.Errorf("detectViaLoginctl() environment = %v, want %v", env, tt.expectedEnv)
+			}
+			if (err != nil) != tt.expectError {
+				t.Errorf("detectViaLoginctl() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}
 
 func TestEnvironmentDetector(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Running as a system service requires access to /run/user/<uid>/ which
contains sensitive sockets (D-Bus, GPG agent, SSH agent). Using ACLs
to grant access is a security risk.

Switch to a systemd user service that runs under the logged-in user's
account, automatically inheriting DISPLAY, WAYLAND_DISPLAY, and D-Bus
session bus. Users enable the service with:

  systemctl --user enable --now screenshooter-mcp.service

The postinst script runs daemon-reload for currently logged-in users.

In addition to this, we add a fallback mechanism to get the session type 
through loginctl. This may not work as intended, but it should help to 
detect the backend if required.