### PR TITLE
tests: implement some integration test on all supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ Arguments:
 - wlroots-based compositor (recommended)
 - or xdg-desktop-portal backend
 
+## Testing
+
+Integration tests in `tests/integration/` create VMs using KVM/libvirt to test the MCP server end-to-end. They are designed to run on a Debian/Ubuntu workstation with KVM virtualization enabled.
+
+To run a test:
+```bash
+cd tests/integration
+./run.sh debian 12 gnome wayland
+```
+
+See `tests/integration/README.md` for requirements and supported configurations.
+
 ## License
 
 MIT

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,13 @@
+images/
+keys/
+isos/
+bases/
+vms/
+pkg/
+*.qcow2
+*.qcow2.bz2
+*.qcow2.gz
+*.img
+*.iso
+*.log
+test-mcp

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -10,4 +10,3 @@ pkg/
 *.img
 *.iso
 *.log
-test-mcp

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,189 @@
+# ScreenshooterMCP Integration Tests
+
+This directory contains integration tests that run the MCP server in VMs to verify end-to-end functionality.
+
+## Overview
+
+The tests create virtual machines using KVM/libvirt, install a distribution with aDesktop environment, and run the ScreenshooterMCP server to test screenshot capture functionality.
+
+## Requirements
+
+### Hardware Requirements
+- **KVM-capable CPU** with hardware virtualization (Intel VT-x or AMD-V)
+- **RAM**: 16GB+ recommended (8GB per VM, can run 2+ VMs simultaneously)
+- **Disk Space**: 200GB+ recommended
+  - Base images: ~30GB each (Debian/Ubuntu GNOME), ~45GB (KDE)
+  - VM clones: Same size as base images
+  - Plan for ~50GB per VM (base + clone)
+
+### Software Requirements
+
+The following packages must be installed on the host:
+
+#### Essential Packages
+```
+# Debian/Ubuntu
+apt install -y \
+    qemu-system-x86 \
+    qemu-utils \
+    libvirt-daemon-system \
+    libvirt-clients \
+    virt-manager \
+    virtinst \
+    guestfs-tools \
+    cloud-image-utils \
+    genisoimage \
+    jq \
+    openssh-client
+```
+
+#### For osinfo-db (required for --osinfo flag with virt-install)
+```
+# Install a recent version
+apt install -y libosinfo-bin
+
+# Or update via
+dpkg -l | grep osinfo
+```
+
+To check your osinfo-db version:
+```
+osinfo-query-os | grep -E "debian|ubuntu|fedora" | head
+```
+
+A recent osinfo-db (2024 or newer) is recommended for proper VM template detection.
+
+### Network Requirements
+- **libvirt default network** must be active (NAT mode)
+- VMs require internet access to download packages during install
+
+## Supported Configurations
+
+| Distribution | Version | Desktop | Mode | Status |
+|------------|---------|--------|------|--------|
+| Debian     | 12, 13  | GNOME  | Wayland | ✓     |
+| Debian     | 12, 13  | KDE    | X11   | ✓     |
+| Debian     | 12, 13  | KDE    | Wayland | ✓     |
+| Ubuntu    | 24.04   | GNOME  | Wayland | ✓     |
+| Ubuntu    | 24.04   | KDE    | Wayland | ✓     |
+| Ubuntu    | 26.04   | GNOME  | Wayland | ✓     |
+| Ubuntu    | 26.04   | KDE    | Wayland | ✓     |
+| Fedora    | 43      | GNOME  | Wayland | ✓     |
+| Fedora    | 43      | KDE    | Wayland | ✓     |
+| Fedora    | 43      | GNOME  | X11   | ✗     |
+| Fedora    | 43      | KDE    | X11   | ✗     |
+
+**Note**: Fedora 43 does not support X11 mode. The tests will reject these combinations.
+
+## Wayland Test Status
+
+**All Wayland tests are expected to fail** in the current project state. This is due to Wayland screen capture not being fully implemented.
+
+The tests can create VMs and run the MCP server, but capture operations will fail when attempting to capture screens on Wayland.
+
+Current workarounds:
+1. Use X11 mode where supported (Debian KDE/X11, Ubuntu KDE/X11)
+2. Wait for Wayland support to be implemented
+
+## Usage
+
+### Quick Start
+
+```bash
+cd tests/integration
+
+# Run a single test
+./run.sh debian 12 gnome wayland
+
+# List available configurations
+./run.sh
+
+# Provision a VM without running tests
+./lib/provision-vm.sh <distro> <version> <desktop> <mode>
+```
+
+### Creating Base Images
+
+Base images must be created before running tests:
+
+```bash
+# Create base image for Debian 12 GNOME
+./lib/create-base-image.sh debian 12 gnome
+
+# Create base image for Ubuntu 24.04 KDE  
+./lib/create-base-image.sh ubuntu 24.04 kde
+```
+
+### Downloading ISOs
+
+ISOs are downloaded automatically when creating base images. To pre-download:
+
+```bash
+./lib/download-iso.sh debian 12 gnome
+./lib/download-iso.sh ubuntu 24.04 kde
+```
+
+## Directory Structure
+
+```
+tests/integration/
+├── bases/           # Base VM images (templates)
+├── vms/           # VM clones for testing
+├── isos/          # Downloaded ISO files
+├── keys/          # SSH keys, passwords
+├── pkg/           # Downloaded packages
+├── lib/           # Helper scripts
+│   ├── create-base-image.sh
+│   ├── provision-vm.sh
+│   ├── download-iso.sh
+│   ├── download-package.sh
+│   └── ...
+├── shared/         # Test clients (test-mcp)
+└── run.sh         # Main test runner
+```
+
+## Troubleshooting
+
+### "No valid CPU mode"
+Ensure CPU virtualization is enabled in BIOS/UEFI.
+
+### "Network 'default' not found"
+Run:
+```bash
+virsh net-define /dev/stdin <<EOF
+<network>
+  <name>default</name>
+  <forward mode='nat'/>
+  <bridge name='virbr0' stp='on' delay='0'/>
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.122.2' end='192.168.122.254'/>
+    </dhcp>
+  </ip>
+</network>
+EOF
+virsh net-start default
+virsh net-autostart default
+```
+
+### Disk space issues
+Remove old VMs:
+```bash
+virsh destroy test-*
+virsh undefine test-* --nvram
+rm -f vms/*.qcow2
+```
+
+### Permission issues
+Some operations require root:
+```bash
+sudo chown $USER:$USER /var/lib/libvirt/qemu/nvram/
+```
+
+## Notes
+
+- Tests use **transient VMs** (destroyed after test)
+- Each test run creates a fresh VM clone
+- VM images use UEFI boot with OVMF
+- Serial console is configured for debugging
+- cloud-init is used for VM configuration (Ubuntu)

--- a/tests/integration/lib/create-base-image.sh
+++ b/tests/integration/lib/create-base-image.sh
@@ -81,12 +81,16 @@ get_install_with_task() {
 }
 
 create_debian_image() {
+	local sz=30
+
+	[ "${2}" = "kde" ] && sz=45
+
 	echo "Starting virt-install for Debian..."
 	virt-install \
 		--name "$VM_NAME" \
 		--memory 8192 \
 		--vcpus 2 \
-		--disk path="$BASE_IMAGE",format=qcow2,size=30 \
+		--disk path="$BASE_IMAGE",format=qcow2,size=${sz} \
 		--location "$ISO_FILE" \
 		--graphics spice \
 		--video virtio \

--- a/tests/integration/lib/create-base-image.sh
+++ b/tests/integration/lib/create-base-image.sh
@@ -197,8 +197,9 @@ create_fedora_image() {
 	echo "Post-install customization..."
 	virt-customize \
 		-a "$BASE_IMAGE" \
-		--install spice-vdagent,spice-webdavd,qemu-guest-agent,openssh-client,openssh-server,cloud-init,sudo \
+		--install spice-vdagent,spice-webdavd,qemu-guest-agent,openssh,openssh-server,cloud-init,sudo \
 		--run-command "dnf install -y $(get_install_with_dnf "${2}")" \
+		--run-command "dnf install -y openssh" \
 		--ssh-inject "tester:file:${SSH_KEY}" \
 		--run-command "echo 'tester ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tester" \
 		--run-command "chmod 440 /etc/sudoers.d/tester" \

--- a/tests/integration/lib/create-base-image.sh
+++ b/tests/integration/lib/create-base-image.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Creates base VM image from ISO using virt-install with autoinstall
+# Usage: ./create-base-image.sh <distro> <version> <desktop>
+#
+# Creates a base image with:
+# - tester user with SSH key-based access
+# - sudo privileges
+# - cloud-init and SSH server enabled
+#
+# Base images are stored in ../bases/
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KEYS_DIR="$(cd "$SCRIPT_DIR/../keys" && pwd)"
+ISOS_DIR="$(cd "$SCRIPT_DIR/../isos" && pwd)"
+BASES_DIR="$(cd "$SCRIPT_DIR/../bases" && pwd)"
+SSH_KEY="${KEYS_DIR}/test-key.pub"
+
+DISTRO="$1"
+VERSION="$2"
+DESKTOP="$3"
+
+if [ -z "$DISTRO" ] || [ -z "$VERSION" ] || [ -z "$DESKTOP" ]; then
+	echo "Usage: $0 <distro> <version> <desktop>"
+	echo "  distro: debian, ubuntu, fedora"
+	echo "  version: 12, 13, 24.04, 25.10, 26.04, 42, 43"
+	echo "  desktop: gnome, kde"
+	exit 1
+fi
+
+VM_NAME="base-${DISTRO}-${VERSION}-${DESKTOP}"
+BASE_IMAGE="${BASES_DIR}/${DISTRO}-${VERSION}-${DESKTOP}.qcow2"
+ISO_FILE="${ISOS_DIR}/${DISTRO}-${VERSION}-${DESKTOP}.iso"
+
+if [ -f "$BASE_IMAGE" ]; then
+	echo "Base image already exists: $BASE_IMAGE"
+	exit 0
+fi
+
+if [ ! -f "$SSH_KEY" ]; then
+	echo "SSH key not found. Run create-ssh-key.sh first."
+	exit 1
+fi
+
+if [ ! -f "$ISO_FILE" ]; then
+	echo "ISO not found. Run download-iso.sh first."
+	exit 1
+fi
+
+mkdir -p "$BASES_DIR"
+
+wait_for_shutdown() {
+	local vm="$1"
+	local timeout=60
+	local count=0
+
+	while virsh domstate "$vm" 2>/dev/null | grep -q running; do
+		sleep 1
+		count=$((count + 1))
+		if [ $count -ge $timeout ]; then
+			echo "Warning: VM did not shutdown within ${timeout}s, forcing..."
+			virsh destroy "$vm" 2>/dev/null || true
+			break
+		fi
+	done
+}
+
+get_install_with_task() {
+	case "${1}" in
+	[gG][nN][oO][mM][eE])
+		echo gnome-desktop
+		;;
+	[kK][dD][eE])
+		echo kde-desktop
+		;;
+	*)
+		echo gnome-desktop
+		;;
+	esac
+}
+
+create_debian_image() {
+	echo "Starting virt-install for Debian..."
+	virt-install \
+		--name "$VM_NAME" \
+		--memory 8192 \
+		--vcpus 2 \
+		--disk path="$BASE_IMAGE",format=qcow2,size=30 \
+		--location "$ISO_FILE" \
+		--graphics spice \
+		--video virtio \
+		--osinfo debian${1} \
+		--unattended "user-login=tester,user-password-file=${KEYS_DIR}/user-password-file,admin-password-file=${KEYS_DIR}/admin-password-file" \
+		--extra-args "tasksel:tasksel/first=$(get_install_with_task ${2})" \
+		--boot uefi \
+		--transient \
+		--wait 60
+
+	echo "Change the owner of the generated base image"
+	sudo chown "$USER:$USER" "$BASE_IMAGE"
+	chmod 0644 "$BASE_IMAGE"
+
+	echo "Post-install customization..."
+	virt-customize \
+		-a "$BASE_IMAGE" \
+		--install spice-vdagent,spice-webdavd,qemu-guest-agent,openssh-client,openssh-server,cloud-init,sudo \
+		--ssh-inject "tester:file:${SSH_KEY}" \
+		--run-command "echo 'tester ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tester" \
+		--run-command "chmod 440 /etc/sudoers.d/tester" \
+		--run-command "systemctl enable cloud-init" \
+		--run-command "systemctl enable cloud-init-local" \
+		--run-command "systemctl enable cloud-config" \
+		--run-command "systemctl enable cloud-final" \
+		--run-command "systemctl enable ssh || systemctl enable sshd" \
+		--run-command "systemctl enable spice-vdagentd" \
+		--run-command "systemctl enable qemu-guest-agent" \
+		--selinux-relabel || true
+}
+
+create_ubuntu_image() {
+	echo "Starting virt-install for Ubuntu..."
+	virt-install \
+		--name "$VM_NAME" \
+		--memory 8192 \
+		--vcpus 2 \
+		--disk path="$BASE_IMAGE",format=qcow2,size=30 \
+		--location "$ISO_FILE" \
+		--graphics spice \
+		--video virtio \
+		--osinfo ubuntu${1} \
+		--unattended "user-login=tester,user-password-file=${KEYS_DIR}/user-password-file,admin-password-file=${KEYS_DIR}/admin-password-file" \
+		--boot uefi \
+		--transient \
+		--wait 60
+
+	echo "Change the owner of the generated base image"
+	sudo chown "$USER:$USER" "$BASE_IMAGE"
+	chmod 0644 "$BASE_IMAGE"
+
+	echo "Post-install customization..."
+	virt-customize \
+		-a "$BASE_IMAGE" \
+		--install spice-vdagent,spice-webdavd,qemu-guest-agent,openssh-client,openssh-server,cloud-init,sudo \
+		--ssh-inject "tester:file:${SSH_KEY}" \
+		--run-command "echo 'tester ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tester" \
+		--run-command "chmod 440 /etc/sudoers.d/tester" \
+		--run-command "systemctl enable cloud-init" \
+		--run-command "systemctl enable cloud-init-local" \
+		--run-command "systemctl enable cloud-config" \
+		--run-command "systemctl enable cloud-final" \
+		--run-command "systemctl enable ssh || systemctl enable sshd" \
+		--run-command "systemctl enable spice-vdagentd" \
+		--run-command "systemctl enable qemu-guest-agent" \
+		--selinux-relabel || true
+}
+
+get_install_with_dnf() {
+	case "${1}" in
+	[gG][nN][oO][mM][eE])
+		echo "@gnome-desktop"
+		;;
+	[kK][dD][eE])
+		echo "@kde-desktop-environment"
+		;;
+	*)
+		echo "@gnome-desktop"
+		;;
+	esac
+}
+
+create_fedora_image() {
+	echo "Starting virt-install for Fedora..."
+
+	virt-install \
+		--name "$VM_NAME" \
+		--memory 8192 \
+		--vcpus 2 \
+		--disk path="$BASE_IMAGE",format=qcow2,size=30 \
+		--location "$ISO_FILE" \
+		--graphics spice \
+		--video virtio \
+		--osinfo fedora${1} \
+		--unattended "user-login=tester,user-password-file=${KEYS_DIR}/user-password-file,admin-password-file=${KEYS_DIR}/admin-password-file" \
+		--boot uefi \
+		--transient \
+		--wait 60
+
+	echo "Change the owner of the generated base image"
+	sudo chown "$USER:$USER" "$BASE_IMAGE"
+	chmod 0644 "$BASE_IMAGE"
+
+	echo "Post-install customization..."
+	virt-customize \
+		-a "$BASE_IMAGE" \
+		--install spice-vdagent,spice-webdavd,qemu-guest-agent,openssh-client,openssh-server,cloud-init,sudo \
+		--run-command "dnf install -y $(get_install_with_dnf "${2}")" \
+		--ssh-inject "tester:file:${SSH_KEY}" \
+		--run-command "echo 'tester ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tester" \
+		--run-command "chmod 440 /etc/sudoers.d/tester" \
+		--run-command "systemctl enable cloud-init" \
+		--run-command "systemctl enable cloud-init-local" \
+		--run-command "systemctl enable cloud-config" \
+		--run-command "systemctl enable cloud-final" \
+		--run-command "systemctl enable ssh || systemctl enable sshd" \
+		--run-command "systemctl enable spice-vdagentd" \
+		--run-command "systemctl enable qemu-guest-agent" \
+		--selinux-relabel || true
+}
+
+echo "Creating base image for $DISTRO $VERSION ($DESKTOP)..."
+echo "  VM name: $VM_NAME"
+echo "  Base image: $BASE_IMAGE"
+echo "  ISO: $ISO_FILE"
+
+case "$DISTRO" in
+	debian)
+		create_debian_image $VERSION $DESKTOP
+		;;
+	ubuntu)
+		create_ubuntu_image $VERSION $DESKTOP
+		;;
+	fedora)
+		create_fedora_image $VERSION $DESKTOP
+		;;
+	*)
+		echo "Unsupported distro: $DISTRO"
+		exit 1
+		;;
+esac
+
+echo "Base image created: $BASE_IMAGE"

--- a/tests/integration/lib/create-base-image.sh
+++ b/tests/integration/lib/create-base-image.sh
@@ -122,33 +122,83 @@ create_debian_image() {
 		--selinux-relabel || true
 }
 
+get_ubuntu_desktop_package() {
+	case "${1}" in
+	kde)
+		echo kde-plasma-desktop,sddm,sddm-theme-breeze
+		;;
+	*)
+		echo ubuntu-desktop,gdm3
+		;;
+	esac
+}
+
 create_ubuntu_image() {
+	local user_password
+	local password_hash
+	local ssh_pubkey
+
+	echo "Create the autoinstall seed [requires root]"
+	user_password="$(cat "${KEYS_DIR}/user-password-file")"
+	password_hash="$(openssl passwd -6 -salt "$(openssl rand -base64 8)" "$user_password")"
+	ssh_pubkey="$(cat "${SSH_KEY}")"
+
+	# WARNING - take care, these are spaces, not tabs
+	cat > "${KEYS_DIR}/user-data" <<EOF
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: ubuntu-test
+    username: tester
+    password: "${password_hash}"
+  ssh:
+    install-server: true
+    authorized-keys:
+      - "${ssh_pubkey}"
+  storage:
+    layout:
+      name: lvm
+  late-commands:
+    - echo 'tester ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/tester
+    - chmod 440 /target/etc/sudoers.d/tester
+EOF
+
+	touch "${KEYS_DIR}/meta-data"
+
+	(
+		cd "${KEYS_DIR}"
+		[ -f seed.iso ] && sudo chown $USER:$USER seed.iso
+		rm -f seed.iso
+		genisoimage -output seed.iso \
+			-volid cidata \
+			-joliet -rock \
+			"user-data" "meta-data"
+	)
+
 	echo "Starting virt-install for Ubuntu..."
 	virt-install \
 		--name "$VM_NAME" \
 		--memory 8192 \
 		--vcpus 2 \
 		--disk path="$BASE_IMAGE",format=qcow2,size=30 \
-		--location "$ISO_FILE" \
+		--cdrom "$ISO_FILE" \
+		--disk path="${KEYS_DIR}/seed.iso",device=cdrom \
 		--graphics spice \
 		--video virtio \
 		--osinfo ubuntu${1} \
-		--unattended "user-login=tester,user-password-file=${KEYS_DIR}/user-password-file,admin-password-file=${KEYS_DIR}/admin-password-file" \
 		--boot uefi \
 		--transient \
 		--wait 60
 
-	echo "Change the owner of the generated base image"
+	echo "Change the owner of the generated base image [requires root]"
 	sudo chown "$USER:$USER" "$BASE_IMAGE"
 	chmod 0644 "$BASE_IMAGE"
 
 	echo "Post-install customization..."
 	virt-customize \
 		-a "$BASE_IMAGE" \
-		--install spice-vdagent,spice-webdavd,qemu-guest-agent,openssh-client,openssh-server,cloud-init,sudo \
-		--ssh-inject "tester:file:${SSH_KEY}" \
-		--run-command "echo 'tester ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tester" \
-		--run-command "chmod 440 /etc/sudoers.d/tester" \
+		--install $(get_ubuntu_desktop_package "${2}"),spice-vdagent,spice-webdavd,qemu-guest-agent,openssh-client,openssh-server,cloud-init,sudo \
 		--run-command "systemctl enable cloud-init" \
 		--run-command "systemctl enable cloud-init-local" \
 		--run-command "systemctl enable cloud-config" \
@@ -156,6 +206,9 @@ create_ubuntu_image() {
 		--run-command "systemctl enable ssh || systemctl enable sshd" \
 		--run-command "systemctl enable spice-vdagentd" \
 		--run-command "systemctl enable qemu-guest-agent" \
+		--run-command "systemctl enable gdm3 || true" \
+		--run-command "systemctl enable sddm || true" \
+		--run-command "systemctl set-default graphical.target" \
 		--selinux-relabel || true
 }
 

--- a/tests/integration/lib/create-cloud-init.sh
+++ b/tests/integration/lib/create-cloud-init.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Creates cloud-init user-data for Ubuntu autoinstall
+# Usage: ./create-cloud-init.sh <version> <ssh_pubkey>
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION="$1"
+SSH_PUBKEY="$2"
+
+if [ -z "$VERSION" ] || [ -z "$SSH_PUBKEY" ]; then
+	echo "Usage: $0 <version> <ssh_pubkey_file>"
+	exit 1
+fi
+
+if [ ! -f "$SSH_PUBKEY" ]; then
+	echo "SSH public key file not found: $SSH_PUBKEY"
+	exit 1
+fi
+
+SSH_KEY="$(cat "$SSH_PUBKEY")"
+
+cat << EOF
+#cloud-config
+autoinstall:
+  version: 3
+  identity:
+    hostname: ubuntu-${VERSION}-test
+    username: tester
+    password: ''  # no password, key-only auth
+  ssh:
+    install-server: true
+    authorized-keys:
+      - "${SSH_KEY}"
+  packages:
+    - openssh-server
+    - cloud-init
+    - vim
+  late-commands:
+    - echo 'tester ALL=(ALL) NOPASSWD: ALL' > /target/etc/sudoers.d/tester
+    - chmod 0440 /target/etc/sudoers.d/tester
+EOF

--- a/tests/integration/lib/create-kickstart.sh
+++ b/tests/integration/lib/create-kickstart.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Creates Fedora kickstart configuration
+# Usage: ./create-kickstart.sh <version> <ssh_pubkey>
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION="$1"
+SSH_PUBKEY="$2"
+
+if [ -z "$VERSION" ] || [ -z "$SSH_PUBKEY" ]; then
+	echo "Usage: $0 <version> <ssh_pubkey_file>"
+	exit 1
+fi
+
+if [ ! -f "$SSH_PUBKEY" ]; then
+	echo "SSH public key file not found: $SSH_PUBKEY"
+	exit 1
+fi
+
+SSH_KEY="$(cat "$SSH_PUBKEY")"
+
+cat << EOF
+# Kickstart for Fedora
+# https://docs.fedoraproject.org/en-US/fedora/latest/html/install-guide/appe-Kickstart_Syntax_Reference.html
+
+# System language
+lang en_US.UTF-8
+
+# Keyboard layouts
+keyboard us
+
+# System timezone
+timezone UTC --utc
+
+# Root password (empty, SSH key only)
+rootpw --iscrypted --allow-empty
+sshkey --username=root "${SSH_KEY}"
+
+# Use text mode install
+text
+
+# Run the Setup Agent on first boot
+firstboot --enable
+
+# System services
+services --enabled=sshd,cloud-init
+
+# SELinux
+selinux --enforcing
+
+# Network information
+network --bootproto=dhcp --device=link --activate --ipv6=auto --type
+
+# Halt after installation
+shutdown
+
+# System bootloader
+bootloader --location=mbr
+
+# Clear disk
+clearpart --all --initlabel --drives=sda
+
+# Partition layout
+part /boot --fstype=xfs --size=512 --ondisk=sda
+part pv.01 --size=6144 --fstype=xfs --grow --ondisk=sda
+volgroup vg_root pv.01
+logvol / --fstype=xfs --size=4096 --name=lv_root --volgroup=vg_root --grow
+logvol swap --fstype=swap --size=2048 --name=lv_swap --volgroup=vg_root
+
+# Package selection (desktop environment added via live iso, but ensure packages)
+%packages
+@^workstation-product-environment
+openssh-server
+cloud-init
+vim
+%end
+
+# Post installation
+%post
+#!/bin/bash
+useradd -m -s /bin/bash tester
+echo 'tester ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/tester
+chmod 0440 /etc/sudoers.d/tester
+mkdir -p /home/tester/.ssh
+echo '${SSH_KEY}' > /home/tester/.ssh/authorized_keys
+chown -R tester:tester /home/tester/.ssh
+chmod 0700 /home/tester/.ssh
+chmod 0600 /home/tester/.ssh/authorized_keys
+%end
+EOF

--- a/tests/integration/lib/create-preseed.sh
+++ b/tests/integration/lib/create-preseed.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Creates Debian preseed configuration
+# Usage: ./create-preseed.sh <version> <ssh_pubkey>
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION="$1"
+SSH_PUBKEY="$2"
+
+if [ -z "$VERSION" ] || [ -z "$SSH_PUBKEY" ]; then
+	echo "Usage: $0 <version> <ssh_pubkey_file>"
+	exit 1
+fi
+
+if [ ! -f "$SSH_PUBKEY" ]; then
+	echo "SSH public key file not found: $SSH_PUBKEY"
+	exit 1
+fi
+
+SSH_KEY="$(cat "$SSH_PUBKEY")"
+
+cat << EOF
+# Preseed for Debian netinst
+# https://www.debian.org/releases/stable/amd64/apb.en.html
+
+#### Contents of the preconfiguration file
+### Localization
+d-i debian-installer/locale string en_US.UTF-8
+d-i debian-installer/language string en
+d-i debian-installer/country string US
+
+### Network configuration
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string debian-${VERSION}-test
+d-i netcfg/get_domain string localdomain
+
+### Mirror settings
+d-i mirror/countryselect select US
+d-i mirror/http/hostname string deb.debian.org
+d-i mirror/http/directory string /debian
+d-i mirror/http/proxy string
+
+### Partitioning
+d-i partman-auto/method string regular
+d-i partman-auto/choose_recipe select atomic
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+### Account setup
+d-i passwd/make-user boolean true
+d-i passwd/user-uid string 1000
+d-i passwd/user-fullname string Tester User
+d-i passwd/username string tester
+d-i passwd/user-password-crypted password ''
+d-i user-setup/allow-password-empty boolean true
+d-i user-setup/encrypt-home boolean false
+
+### Package selection
+tasksel tasksel/first multiselect standard, desktop, gnome-desktop, kde-desktop
+d-i pkgsel/include string openssh-server cloud-init vim
+
+### Bootloader
+d-i grub-installer/bootdev string default
+
+### Post installation
+d-i preseed/late_command string \\
+    echo 'tester ALL=(ALL) NOPASSWD: ALL' > /target/etc/sudoers.d/tester; \\
+    chmod 0440 /target/etc/sudoers.d/tester; \\
+    mkdir -p /target/home/tester/.ssh; \\
+    echo '${SSH_KEY}' > /target/home/tester/.ssh/authorized_keys; \\
+    chown -R tester:tester /target/home/tester/.ssh; \\
+    chmod 0700 /target/home/tester/.ssh; \\
+    chmod 0600 /target/home/tester/.ssh/authorized_keys
+EOF

--- a/tests/integration/lib/create-ssh-key.sh
+++ b/tests/integration/lib/create-ssh-key.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Generates SSH key for test VM access
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KEYS_DIR="$(cd "$SCRIPT_DIR/../keys" && pwd)"
+KEY_FILE="$KEYS_DIR/test-key"
+
+if [ -f "$KEY_FILE" ] && [ -f "${KEY_FILE}.pub" ]; then
+    echo "SSH key already exists at $KEY_FILE"
+    exit 0
+fi
+
+echo "Generating SSH key for test VM access..."
+mkdir -p "$KEYS_DIR"
+ssh-keygen -t ed25519 -f "$KEY_FILE" -N "" -C "screenshooter-mcp test key"
+chmod 600 "$KEY_FILE"
+chmod 644 "${KEY_FILE}.pub"
+
+echo "SSH key generated successfully:"
+echo "  Private: $KEY_FILE"
+echo "  Public:  ${KEY_FILE}.pub"

--- a/tests/integration/lib/download-iso.sh
+++ b/tests/integration/lib/download-iso.sh
@@ -33,17 +33,11 @@ download_debian() {
 
 	local iso_url
 	case "${version}-${desktop}" in
-		12-gnome)
+		12-gnome|12-kde)
 			iso_url="https://cdimage.debian.org/cdimage/archive/12.13.0/amd64/iso-cd/debian-12.13.0-amd64-netinst.iso"
 			;;
-		12-kde)
-			iso_url="https://cdimage.debian.org/cdimage/archive/12.13.0/amd64/iso-cd/debian-12.13.0-amd64-netinst.iso"
-			;;
-		13-gnome)
-			iso_url="https://cdimage.debian.org/mirror/cdimage/archive/13.3.0/amd64/iso-cd/debian-13.3.0-amd64-netinst.iso"
-			;;
-		13-kde)
-			iso_url="https://cdimage.debian.org/mirror/cdimage/archive/13.3.0/amd64/iso-cd/debian-13.3.0-amd64-netinst.iso"
+		13-gnome|13-kde)
+			iso_url="https://cdimage.debian.org/mirror/cdimage/archive/13.3.0/amd64/iso-cd/debian-13.4.0-amd64-netinst.iso"
 			;;
 		*)
 			echo "Unsupported Debian version/desktop: $version $desktop"
@@ -68,7 +62,7 @@ download_ubuntu() {
 			iso_url="https://releases.ubuntu.com/25.10/ubuntu-25.10-live-server-amd64.iso"
 			;;
 		26.04)
-			iso_url="https://releases.ubuntu.com/26.04/ubuntu-26.04-beta-live-server-amd64.iso"
+			iso_url="https://releases.ubuntu.com/26.04/ubuntu-26.04-live-server-amd64.iso"
 			;;
 		*)
 			echo "Unsupported Ubuntu version: $version"

--- a/tests/integration/lib/download-iso.sh
+++ b/tests/integration/lib/download-iso.sh
@@ -86,9 +86,6 @@ download_fedora() {
 
 	local iso_url
 	case "${version}-${desktop}" in
-		42-gnome|42-kde)
-				iso_url="https://download.fedoraproject.org/pub/fedora/linux/releases/42/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-42-1.1.iso"
-				;;
 		43-gnome|43-kde)
     	iso_url="https://download.fedoraproject.org/pub/fedora/linux/releases/43/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-43-1.6.iso"
     	;;

--- a/tests/integration/lib/download-iso.sh
+++ b/tests/integration/lib/download-iso.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Downloads ISO images for test VMs
+# Usage: ./download-iso.sh <distro> <version> <desktop>
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ISOS_DIR="$(cd "$SCRIPT_DIR/../isos" && pwd)"
+DOWNLOAD_DIR="$ISOS_DIR"
+
+check_and_download() {
+	local iso_url="$1"
+	local iso_file="$2"
+
+	if [ -f "$iso_file" ]; then
+		echo "ISO already exists: $iso_file"
+		return 0
+	fi
+
+	if curl -sIL -o /dev/null -w "%{http_code}" "$iso_url" 2>/dev/null | grep -q "200"; then
+		echo "Downloading $iso_url ..."
+		curl -L -o "$iso_file" "$iso_url"
+	else
+		echo "ERROR: ISO not found at $iso_url"
+		return 1
+	fi
+}
+
+download_debian() {
+	local version="$1"
+	local desktop="$2"
+	local iso_file="$DOWNLOAD_DIR/debian-${version}-${desktop}.iso"
+
+	local iso_url
+	case "${version}-${desktop}" in
+		12-gnome)
+			iso_url="https://cdimage.debian.org/cdimage/archive/12.13.0/amd64/iso-cd/debian-12.13.0-amd64-netinst.iso"
+			;;
+		12-kde)
+			iso_url="https://cdimage.debian.org/cdimage/archive/12.13.0/amd64/iso-cd/debian-12.13.0-amd64-netinst.iso"
+			;;
+		13-gnome)
+			iso_url="https://cdimage.debian.org/mirror/cdimage/archive/13.3.0/amd64/iso-cd/debian-13.3.0-amd64-netinst.iso"
+			;;
+		13-kde)
+			iso_url="https://cdimage.debian.org/mirror/cdimage/archive/13.3.0/amd64/iso-cd/debian-13.3.0-amd64-netinst.iso"
+			;;
+		*)
+			echo "Unsupported Debian version/desktop: $version $desktop"
+			return 1
+			;;
+	esac
+
+	check_and_download "$iso_url" "$iso_file"
+}
+
+download_ubuntu() {
+	local version="$1"
+	local desktop="$2"
+	local iso_file="$DOWNLOAD_DIR/ubuntu-${version}-${desktop}.iso"
+
+	local iso_url
+	case "${version}" in
+		24.04)
+			iso_url="https://releases.ubuntu.com/24.04/ubuntu-24.04.4-live-server-amd64.iso"
+			;;
+		25.10)
+			iso_url="https://releases.ubuntu.com/25.10/ubuntu-25.10-live-server-amd64.iso"
+			;;
+		26.04)
+			iso_url="https://releases.ubuntu.com/26.04/ubuntu-26.04-beta-live-server-amd64.iso"
+			;;
+		*)
+			echo "Unsupported Ubuntu version: $version"
+			return 1
+			;;
+	esac
+
+	check_and_download "$iso_url" "$iso_file"
+}
+
+download_fedora() {
+	local version="$1"
+	local desktop="$2"
+	local iso_file="$DOWNLOAD_DIR/fedora-${version}-${desktop}.iso"
+
+	local iso_url
+	case "${version}-${desktop}" in
+		42-gnome|42-kde)
+				iso_url="https://download.fedoraproject.org/pub/fedora/linux/releases/42/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-42-1.1.iso"
+				;;
+		43-gnome|43-kde)
+    	iso_url="https://download.fedoraproject.org/pub/fedora/linux/releases/43/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-43-1.6.iso"
+    	;;
+		*)
+			echo "Unsupported Fedora version/desktop: $version $desktop"
+			return 1
+			;;
+	esac
+
+	check_and_download "$iso_url" "$iso_file"
+}
+
+main() {
+	local distro="$1"
+	local version="$2"
+	local desktop="$3"
+
+	if [ -z "$distro" ] || [ -z "$version" ] || [ -z "$desktop" ]; then
+		echo "Usage: $0 <distro> <version> <desktop>"
+		echo "  distro: debian, ubuntu, fedora"
+		echo "  version: 12, 13, 24.04, 25.10, 26.04, 42, 43"
+		echo "  desktop: gnome, kde"
+		exit 1
+	fi
+
+	case "$distro" in
+		debian)
+			download_debian "$version" "$desktop"
+			;;
+		ubuntu)
+			download_ubuntu "$version" "$desktop"
+			;;
+		fedora)
+			download_fedora "$version" "$desktop"
+			;;
+		*)
+			echo "Unsupported distro: $distro"
+			exit 1
+			;;
+	esac
+}
+
+main "$@"

--- a/tests/integration/lib/download-package.sh
+++ b/tests/integration/lib/download-package.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Downloads package from GitHub releases
+# Usage: ./download-package.sh <distro> [version]
+#
+# Checks local directory first, downloads from GitHub if not found.
+# Package is stored in ../pkg/
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+PKG_DIR="${SCRIPT_DIR}/../pkg"
+mkdir -p "${PKG_DIR}"
+PKG_DIR="$(cd "$SCRIPT_DIR/../pkg" && pwd)"
+REPO="emmanuel-deloget/screenshooter-mcp"
+
+DISTRO="$1"
+VERSION="${2:-latest}"
+
+mkdir -p "$PKG_DIR"
+
+find_local_package() {
+	local distro="$1"
+	local pattern
+
+	case "$distro" in
+		debian|ubuntu)
+			pattern="screenshooter-mcp-server_*.deb"
+			;;
+		fedora)
+			pattern="screenshooter-mcp-server-*.rpm"
+			;;
+		*)
+			echo "Unsupported distro: $distro"
+			return 1
+			;;
+	esac
+
+	ls "$PKG_DIR"/${pattern} 2>/dev/null | head -1
+}
+
+download_from_github() {
+	local distro="$1"
+	local version="$2"
+
+	echo "Fetching latest release info from GitHub..."
+	local tag
+	if [ "$version" = "latest" ]; then
+		tag=$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name // empty')
+	else
+		tag="$version"
+	fi
+
+	if [ -z "$tag" ]; then
+		echo "Failed to fetch release info"
+		return 1
+	fi
+
+	echo "Latest release: $tag"
+
+	local assets
+	assets=$(curl -sSL "https://api.github.com/repos/${REPO}/releases/tags/${tag}" | jq -r '.assets[] | .name + " " + .browser_download_url')
+
+	case "$distro" in
+		debian|ubuntu)
+			local deb_url
+			deb_url=$(echo "$assets" | grep -E 'screenshooter-mcp-server_[0-9].*amd64\.deb$' | awk '{print $2}' | head -1)
+			if [ -n "$deb_url" ]; then
+				echo "Downloading $deb_url ..."
+				curl -L -o "${PKG_DIR}/$(basename "$deb_url")" "$deb_url"
+			else
+				echo "No .deb package found for $tag"
+				return 1
+			fi
+			;;
+		fedora)
+			local rpm_url
+			rpm_url=$(echo "$assets" | grep -E 'screenshooter-mcp-server-[0-9].*x86_64\.rpm$' | awk '{print $2}' | head -1)
+			if [ -n "$rpm_url" ]; then
+				echo "Downloading $rpm_url ..."
+				curl -L -o "${PKG_DIR}/$(basename "$rpm_url")" "$rpm_url"
+			else
+				echo "No .rpm package found for $tag"
+				return 1
+			fi
+			;;
+	esac
+}
+
+main() {
+	if [ -z "$DISTRO" ]; then
+		echo "Usage: $0 <distro> [version]"
+		echo "  distro: debian, ubuntu, fedora"
+		echo "  version: specific version or 'latest' (default)"
+		exit 1
+	fi
+
+	local pkg
+	pkg=$(find_local_package "$DISTRO")
+
+	if [ -n "$pkg" ]; then
+		echo "Found local package: $pkg"
+	else
+		download_from_github "$DISTRO" "$VERSION"
+		pkg=$(find_local_package "$DISTRO")
+	fi
+
+	if [ -z "$pkg" ]; then
+		echo "Package not found"
+		exit 1
+	fi
+
+	echo "$pkg"
+}
+
+main "$@"

--- a/tests/integration/lib/download-package.sh
+++ b/tests/integration/lib/download-package.sh
@@ -43,20 +43,20 @@ download_from_github() {
 	local distro="$1"
 	local version="$2"
 
-	echo "Fetching latest release info from GitHub..."
+	echo "Fetching latest tag info from GitHub..."
 	local tag
 	if [ "$version" = "latest" ]; then
-		tag=$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name // empty')
+		tag=$(curl -sSL "https://api.github.com/repos/${REPO}/tags" | jq -r '.[0].name // empty')
 	else
 		tag="$version"
 	fi
 
 	if [ -z "$tag" ]; then
-		echo "Failed to fetch release info"
+		echo "Failed to fetch tag info"
 		return 1
 	fi
 
-	echo "Latest release: $tag"
+	echo "Latest tag: $tag"
 
 	local assets
 	assets=$(curl -sSL "https://api.github.com/repos/${REPO}/releases/tags/${tag}" | jq -r '.assets[] | .name + " " + .browser_download_url')

--- a/tests/integration/lib/provision-vm.sh
+++ b/tests/integration/lib/provision-vm.sh
@@ -93,26 +93,17 @@ configure_display_gnome_mode_fedora() {
 	local disk="$1"
 	local mode="$2"
 
-	case "$mode" in
-		x11)
-			echo "Configuring X11 mode..."
-			virt-customize -a "$disk" \
-				--install xorg-x11-server-Xorg \
-				--firstboot-command "sed -i 's/^#WaylandEnable=false/WaylandEnable=false/' /etc/gdm/custom.conf || true"
-			;;
-		wayland)
-			echo "Wayland is the default mode, nothing to do"
-			;;
-	esac
+	# there is no x11 mode in fedora, but we still need to do some adjustment
 
 	virt-customize -a "$VM_IMAGE" \
+		--run-command "grubby --update-kernel=ALL --args='console=ttyS0,115200n8'" \
 		--run-command "mkdir -p /etc/dconf/db/local.d" \
 		--run-command "printf '[org/gnome/shell]\ndevelopment-tools=true\n' > /etc/dconf/db/local.d/00-screenshooter" \
 		--run-command "mkdir -p /etc/dconf/profile" \
 		--run-command "printf 'user-db:user\nsystem-db:local\nsystem-db:ibus\n' > /etc/dconf/profile/user" \
 		--run-command "dconf update" \
-		--run-command "sed -i 's/^#\s*AutomaticLoginEnable\s*=.*/AutomaticLoginEnable=true/' /etc/gdm3/daemon.conf" \
-		--run-command "sed -i 's/^#\s*AutomaticLogin\s*=.*/AutomaticLogin=tester/' /etc/gdm3/daemon.conf"
+		--run-command "sed -i 's/^#\s*AutomaticLoginEnable\s*=.*/AutomaticLoginEnable=true/' /etc/gdm/custom.conf" \
+		--run-command "sed -i 's/^#\s*AutomaticLogin\s*=.*/AutomaticLogin=tester/' /etc/gdm/custom.conf"
 }
 
 configure_display_mode_kde_debian_ubuntu() {
@@ -137,23 +128,14 @@ configure_display_kde_mode_fedora() {
 	local disk="$1"
 	local mode="$2"
 
-	case "$mode" in
-		x11)
-			echo "Configuring X11 mode..."
-			virt-customize -a "$disk" \
-				--install xorg-x11-server-Xorg \
-				--firstboot-command "sed -i 's/^#WaylandEnable=false/WaylandEnable=false/' /etc/gdm/custom.conf || true"
-			;;
-		wayland)
-			echo "Wayland is the default mode, nothing to do"
-			virt-customize -a "$VM_IMAGE" \
-				--run-command "mkdir -p /etc/sddm.conf.d" \
-				--run-command "printf '[Autologin]\nUser=tester\nSession=plasma\n' > /etc/sddm.conf.d/autologin.conf" \
-				--run-command "printf '[General]\nDefaultSession=plasma-wayland.desktop\n' > /etc/sddm.conf.d/wayland.conf"
-			;;
-	esac
-}
+	# there is no x11 mode in fedora, but we still need to do some adjustment
 
+	virt-customize -a "$VM_IMAGE" \
+		--run-command "grubby --update-kernel=ALL --args='console=ttyS0,115200n8'" \
+		--run-command "mkdir -p /etc/sddm.conf.d" \
+		--run-command "printf '[Autologin]\nUser=tester\nSession=plasma\n' > /etc/sddm.conf.d/autologin.conf" \
+		--run-command "printf '[General]\nDefaultSession=plasma-wayland.desktop\n' > /etc/sddm.conf.d/wayland.conf"
+}
 
 configure_display_mode() {
 	local disk="$1"
@@ -193,6 +175,7 @@ esac
 virt-customize -a "$VM_IMAGE" \
     --run-command "mkdir -p /boot/efi/EFI/BOOT" \
     --run-command "cp ${EFI_SRC} /boot/efi/EFI/BOOT/bootx64.efi" \
+		--run-command "sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/selinux/config || true" \
     --install sudo \
 		--run-command "echo 'tester ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tester" \
 		--run-command "chmod 440 /etc/sudoers.d/tester" \
@@ -223,18 +206,11 @@ fi
 
 virsh net-autostart default
 
-virsh net-list --all
-
 # Define and start VM
 echo "Starting VM..."
 
 virsh destroy "$VM_NAME" 2>/dev/null || true
 virsh undefine "$VM_NAME" --nvram 2>/dev/null || true
-
-echo "Copying NVRAM [requires root]"
-sudo cp "${BASE_NVRAM}" "${VM_NVRAM}"
-sudo chown "$USER:$USER" "$VM_NVRAM"
-chmod 0644 "$VM_NVRAM"
 
 virsh define /dev/stdin << EOF
 <domain type='kvm'>

--- a/tests/integration/lib/provision-vm.sh
+++ b/tests/integration/lib/provision-vm.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# Provisions a test VM from base image
+# Usage: ./provision-vm.sh <distro> <version> <desktop> <mode>
+#
+# Creates a VM clone, configures X11/Wayland mode, and starts it.
+# VM is stored in ../vms/
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASES_DIR="$(cd "$SCRIPT_DIR/../bases" && pwd)"
+VMS_DIR="${SCRIPT_DIR}/../vms"
+mkdir -p "$VMS_DIR"
+VMS_DIR="$(cd "$SCRIPT_DIR/../vms" && pwd)"
+KEYS_DIR="$(cd "$SCRIPT_DIR/../keys" && pwd)"
+
+DISTRO="$1"
+VERSION="$2"
+DESKTOP="$3"
+MODE="$4"
+
+if [ -z "$DISTRO" ] || [ -z "$VERSION" ] || [ -z "$DESKTOP" ] || [ -z "$MODE" ]; then
+	echo "Usage: $0 <distro> <version> <desktop> <mode>"
+	echo "  distro: debian, ubuntu, fedora"
+	echo "  version: 12, 13, 24.04, 25.10, 26.04, 42, 43"
+	echo "  desktop: gnome, kde"
+	echo "  mode: x11, wayland"
+	exit 1
+fi
+
+VM_NAME="test-${DISTRO}-${VERSION}-${DESKTOP}-${MODE}"
+BASE_IMAGE="${BASES_DIR}/${DISTRO}-${VERSION}-${DESKTOP}.qcow2"
+VM_IMAGE="${VMS_DIR}/${VM_NAME}.qcow2"
+BASE_NVRAM="/var/lib/libvirt/qemu/nvram/base-${DISTRO}-${VERSION}-${DESKTOP}_VARS.fd"
+VM_NVRAM="${VMS_DIR}/${VM_NAME}_VARS.fd"
+
+if [ ! -f "$BASE_IMAGE" ]; then
+	echo "Base image not found: $BASE_IMAGE"
+	echo "Run create-base-image.sh first."
+	exit 1
+fi
+
+mkdir -p "$VMS_DIR"
+
+echo "Provisioning VM: $VM_NAME"
+echo "  Base: $BASE_IMAGE"
+echo "  Target: $VM_IMAGE"
+echo "  Mode: $MODE"
+
+# Clone base image (copy to ensure standalone boot)
+if [ -f "$VM_IMAGE" ]; then
+	echo "VM image already exists, removing..."
+	rm -f "$VM_IMAGE"
+fi
+
+cp "$BASE_IMAGE" "$VM_IMAGE"
+echo "Change the owner of the vm image [requires root]"
+sudo chown "$USER:$USER" "$VM_IMAGE"
+chmod 0664 "$VM_IMAGE"
+
+# Ensure disk is bootable - re-read the disk to update permissions
+chmod 0664 "$VM_IMAGE"
+
+# Configure X11/Wayland mode
+configure_display_mode() {
+	local disk="$1"
+	local mode="$2"
+
+	case "$mode" in
+		x11)
+			echo "Configuring X11 mode..."
+			virt-customize -a "$disk" \
+				--firstboot-command "sed -i 's/^#*WaylandEnable=.*/WaylandEnable=false/' /etc/gdm3/custom.conf 2>/dev/null || sed -i 's/^#*WaylandEnable=.*/WaylandEnable=false/' /etc/gdm/custom.conf 2>/dev/null || true"
+			;;
+		wayland)
+			echo "Configuring Wayland mode..."
+			virt-customize -a "$disk" \
+				--firstboot-command "sed -i 's/^#*WaylandEnable=.*/#WaylandEnable=true/' /etc/gdm3/custom.conf 2>/dev/null || sed -i 's/^#*WaylandEnable=.*/#WaylandEnable=true/' /etc/gdm/custom.conf 2>/dev/null || true"
+			;;
+	esac
+}
+
+configure_display_mode "$VM_IMAGE" "$MODE"
+
+echo "Setting up EFI fallback boot entry..."
+case "$DISTRO" in
+    debian)
+        EFI_SRC="/boot/efi/EFI/debian/grubx64.efi"
+        ;;
+    ubuntu)
+        EFI_SRC="/boot/efi/EFI/ubuntu/grubx64.efi"
+        ;;
+    fedora)
+        EFI_SRC="/boot/efi/EFI/fedora/grubx64.efi"
+        ;;
+esac
+
+virt-customize -a "$VM_IMAGE" \
+    --run-command "mkdir -p /boot/efi/EFI/BOOT" \
+    --run-command "cp ${EFI_SRC} /boot/efi/EFI/BOOT/bootx64.efi" \
+    --install sudo \
+		--run-command "echo 'tester ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tester" \
+		--run-command "chmod 440 /etc/sudoers.d/tester"
+
+if ! virsh net-info default &>/dev/null; then
+	echo "Defining the 'default' network"
+	virsh net-define /dev/stdin <<-EOF
+	<network>
+		<name>default</name>
+		<forward mode='nat'/>
+		<bridge name='virbr0' stp='on' delay='0'/>
+		<ip address='192.168.122.1' netmask='255.255.255.0'>
+			<dhcp>
+				<range start='192.168.122.2' end='192.168.122.254'/>
+			</dhcp>
+		</ip>
+	</network>
+	EOF
+fi
+
+if ! virsh net-info default | grep -q "Active:.*yes"; then
+	virsh net-start default
+fi
+
+virsh net-autostart default
+
+virsh net-list --all
+
+# Define and start VM
+echo "Starting VM..."
+
+virsh destroy "$VM_NAME" 2>/dev/null || true
+virsh undefine "$VM_NAME" --nvram 2>/dev/null || true
+
+echo "Copying NVRAM [requires root]"
+sudo cp "${BASE_NVRAM}" "${VM_NVRAM}"
+sudo chown "$USER:$USER" "$VM_NVRAM"
+chmod 0644 "$VM_NVRAM"
+
+virsh define /dev/stdin << EOF
+<domain type='kvm'>
+  <name>$VM_NAME</name>
+  <memory unit='MiB'>8192</memory>
+  <vcpu>2</vcpu>
+	<os>
+		<type arch='x86_64' machine='q35'>hvm</type>
+		<loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.fd</loader>
+		<nvram template='/usr/share/OVMF/OVMF_VARS.fd'/>
+		<boot dev='hd'/>
+	</os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <cpu mode='host-model'/>
+  <devices>
+		<disk type='file'>
+			<driver name='qemu' type='qcow2'/>
+			<source file='$VM_IMAGE'/>
+			<target dev='vda' bus='virtio'/>
+		</disk>
+		<interface type='network'>
+			<source network='default'/>
+			<model type='virtio'/>
+		</interface>
+		<graphics type='spice' autoport='yes'/>
+    <video>
+      <model type='virtio'/>
+    </video>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+    </channel>
+    <console type='pty'>
+      <target type='serial'/>
+    </console>
+  </devices>
+</domain>
+EOF
+
+virsh start "$VM_NAME"
+
+echo "VM $VM_NAME started"
+echo "Waiting for boot and SSH..."
+
+wait_for_ssh() {
+	local vm="$1"
+	local timeout=300
+	local count=0
+
+	while [ $count -lt $timeout ]; do
+		local ip
+		ip=$(virsh domifaddr "$vm" 2>/dev/null | grep ipv4 | head -n 1 | awk '{ print $4 }' | sed 's,/.*$,,')
+
+		if [ -n "$ip" ]; then
+			echo "VM IP: $ip" >&2
+			echo "Checking SSH..." >&2
+			if ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ConnectTimeout=5 -i "${KEYS_DIR}/test-key" "tester@${ip}" "echo ok" 2>/dev/null | grep -q ok; then
+				echo "SSH is ready" >&2
+				echo "$ip"
+				return 0
+			fi
+		fi
+
+		sleep 5
+		count=$((count + 5))
+		echo "Waiting... ${count}s" >&2
+	done
+
+	echo "SSH did not become ready within ${timeout}s" >&2
+	return 1
+}
+
+IP=$(wait_for_ssh "$VM_NAME")
+
+echo "VM provisioned successfully:"
+echo "  Name: $VM_NAME"
+echo "  IP: $IP"
+echo "$IP" > "${VMS_DIR}/${VM_NAME}.ip"
+
+echo "VM_IP=$IP" > "${VMS_DIR}/${VM_NAME}.env"

--- a/tests/integration/lib/provision-vm.sh
+++ b/tests/integration/lib/provision-vm.sh
@@ -62,7 +62,7 @@ chmod 0664 "$VM_IMAGE"
 chmod 0664 "$VM_IMAGE"
 
 # Configure X11/Wayland mode
-configure_display_mode_gnome_debian_ubuntu() {
+configure_display_mode_gnome_debian() {
 	local disk="$1"
 	local mode="$2"
 
@@ -89,6 +89,28 @@ configure_display_mode_gnome_debian_ubuntu() {
 		--run-command "sed -i 's/^#\s*AutomaticLogin\s*=.*/AutomaticLogin=tester/' /etc/gdm3/daemon.conf"
 }
 
+configure_display_mode_gnome_ubuntu() {
+	local disk="$1"
+	local mode="$2"
+
+	case "$mode" in
+		x11)
+			echo "Configuring X11 mode..."
+			virt-customize -a "$disk" \
+				--install xserver-xorg \
+				--firstboot-command "sed -i 's/^#*WaylandEnable=.*/WaylandEnable=false/' /etc/gdm3/daemon.conf 2>/dev/null || true" \
+				--firstboot-command "sed -i 's/^#WaylandEnable=false/WaylandEnable=false/' /etc/gdm3/custom.conf 2> /dev/null || true"
+			;;
+		wayland)
+			echo "Wayland is the default mode, nothing to do"
+			;;
+	esac
+
+	virt-customize -a "$VM_IMAGE" \
+		--run-command "sed -i 's/^#\s*AutomaticLoginEnable\s*=.*/AutomaticLoginEnable=true/' /etc/gdm3/custom.conf || true" \
+		--run-command "sed -i 's/^#\s*AutomaticLogin\s*=.*/AutomaticLogin=tester/' /etc/gdm3/custom.conf || true"
+}
+
 configure_display_gnome_mode_fedora() {
 	local disk="$1"
 	local mode="$2"
@@ -106,17 +128,43 @@ configure_display_gnome_mode_fedora() {
 		--run-command "sed -i 's/^#\s*AutomaticLogin\s*=.*/AutomaticLogin=tester/' /etc/gdm/custom.conf"
 }
 
-configure_display_mode_kde_debian_ubuntu() {
+configure_display_mode_kde_debian() {
 	local disk="$1"
 	local mode="$2"
 
 	case "$mode" in
 		x11)
-			echo "X11 seems to be the default mode, nothing to do"
+			echo "Configuring for X11"
+			virt-customize -a "$VM_IMAGE" \
+				--run-command "mkdir -p /etc/sddm.conf.d" \
+				--run-command "printf '[Autologin]\nUser=tester\nSession=plasma\n' > /etc/sddm.conf.d/autologin.conf"
 			;;
 		wayland)
 			echo "Configuring for Wayland..."
 			virt-customize -a "$VM_IMAGE" \
+				--run-command "mkdir -p /etc/sddm.conf.d" \
+				--run-command "printf '[Autologin]\nUser=tester\nSession=plasmawayland\n' > /etc/sddm.conf.d/autologin.conf" \
+				--run-command "printf '[General]\nDefaultSession=plasmawayland.desktop\n' > /etc/sddm.conf.d/wayland.conf"
+			;;
+	esac
+}
+
+configure_display_mode_kde_ubuntu() {
+	local disk="$1"
+	local mode="$2"
+
+	case "$mode" in
+		x11)
+			echo "Configuring for X11"
+			virt-customize -a "$VM_IMAGE" \
+				--install sddm-theme-breeze \
+				--run-command "mkdir -p /etc/sddm.conf.d" \
+				--run-command "printf '[Autologin]\nUser=tester\nSession=plasma\n' > /etc/sddm.conf.d/autologin.conf"
+			;;
+		wayland)
+			echo "Configuring for Wayland..."
+			virt-customize -a "$VM_IMAGE" \
+				--install sddm-theme-breeze \
 				--run-command "mkdir -p /etc/sddm.conf.d" \
 				--run-command "printf '[Autologin]\nUser=tester\nSession=plasmawayland\n' > /etc/sddm.conf.d/autologin.conf" \
 				--run-command "printf '[General]\nDefaultSession=plasmawayland.desktop\n' > /etc/sddm.conf.d/wayland.conf"
@@ -144,11 +192,17 @@ configure_display_mode() {
 	local desktop="$4"
 
 	case "${distro}-${desktop}" in
-		debian-gnome|ubuntu-gnome)
-			configure_display_mode_gnome_debian_ubuntu "${disk}" "${mode}"
+		debian-gnome)
+			configure_display_mode_gnome_debian "${disk}" "${mode}"
 			;;
-		debian-kde|ubuntu-kde)
-			configure_display_mode_kde_debian_ubuntu "${disk}" "${mode}"
+		ubuntu-gnome)
+			configure_display_mode_gnome_ubuntu "${disk}" "${mode}"
+			;;
+		debian-kde)
+			configure_display_mode_kde_debian "${disk}" "${mode}"
+			;;
+		ubuntu-kde)
+			configure_display_mode_kde_ubuntu "${disk}" "${mode}"
 			;;
 		fedora-gnome)
 			configure_display_gnome_mode_fedora "${disk}" "${mode}"

--- a/tests/integration/lib/provision-vm.sh
+++ b/tests/integration/lib/provision-vm.sh
@@ -78,6 +78,15 @@ configure_display_mode_gnome_debian_ubuntu() {
 			echo "Wayland is the default mode, nothing to do"
 			;;
 	esac
+
+	virt-customize -a "$VM_IMAGE" \
+		--run-command "mkdir -p /etc/dconf/db/local.d" \
+		--run-command "printf '[org/gnome/shell]\ndevelopment-tools=true\n' > /etc/dconf/db/local.d/00-screenshooter" \
+		--run-command "mkdir -p /etc/dconf/profile" \
+		--run-command "printf 'user-db:user\nsystem-db:local\nsystem-db:ibus\n' > /etc/dconf/profile/user" \
+		--run-command "dconf update" \
+		--run-command "sed -i 's/^#\s*AutomaticLoginEnable\s*=.*/AutomaticLoginEnable=true/' /etc/gdm3/daemon.conf" \
+		--run-command "sed -i 's/^#\s*AutomaticLogin\s*=.*/AutomaticLogin=tester/' /etc/gdm3/daemon.conf"
 }
 
 configure_display_gnome_mode_fedora() {
@@ -95,7 +104,56 @@ configure_display_gnome_mode_fedora() {
 			echo "Wayland is the default mode, nothing to do"
 			;;
 	esac
+
+	virt-customize -a "$VM_IMAGE" \
+		--run-command "mkdir -p /etc/dconf/db/local.d" \
+		--run-command "printf '[org/gnome/shell]\ndevelopment-tools=true\n' > /etc/dconf/db/local.d/00-screenshooter" \
+		--run-command "mkdir -p /etc/dconf/profile" \
+		--run-command "printf 'user-db:user\nsystem-db:local\nsystem-db:ibus\n' > /etc/dconf/profile/user" \
+		--run-command "dconf update" \
+		--run-command "sed -i 's/^#\s*AutomaticLoginEnable\s*=.*/AutomaticLoginEnable=true/' /etc/gdm3/daemon.conf" \
+		--run-command "sed -i 's/^#\s*AutomaticLogin\s*=.*/AutomaticLogin=tester/' /etc/gdm3/daemon.conf"
 }
+
+configure_display_mode_kde_debian_ubuntu() {
+	local disk="$1"
+	local mode="$2"
+
+	case "$mode" in
+		x11)
+			echo "X11 seems to be the default mode, nothing to do"
+			;;
+		wayland)
+			echo "Configuring for Wayland..."
+			virt-customize -a "$VM_IMAGE" \
+				--run-command "mkdir -p /etc/sddm.conf.d" \
+				--run-command "printf '[Autologin]\nUser=tester\nSession=plasmawayland\n' > /etc/sddm.conf.d/autologin.conf" \
+				--run-command "printf '[General]\nDefaultSession=plasmawayland.desktop\n' > /etc/sddm.conf.d/wayland.conf"
+			;;
+	esac
+}
+
+configure_display_kde_mode_fedora() {
+	local disk="$1"
+	local mode="$2"
+
+	case "$mode" in
+		x11)
+			echo "Configuring X11 mode..."
+			virt-customize -a "$disk" \
+				--install xorg-x11-server-Xorg \
+				--firstboot-command "sed -i 's/^#WaylandEnable=false/WaylandEnable=false/' /etc/gdm/custom.conf || true"
+			;;
+		wayland)
+			echo "Wayland is the default mode, nothing to do"
+			virt-customize -a "$VM_IMAGE" \
+				--run-command "mkdir -p /etc/sddm.conf.d" \
+				--run-command "printf '[Autologin]\nUser=tester\nSession=plasma\n' > /etc/sddm.conf.d/autologin.conf" \
+				--run-command "printf '[General]\nDefaultSession=plasma-wayland.desktop\n' > /etc/sddm.conf.d/wayland.conf"
+			;;
+	esac
+}
+
 
 configure_display_mode() {
 	local disk="$1"
@@ -107,13 +165,17 @@ configure_display_mode() {
 		debian-gnome|ubuntu-gnome)
 			configure_display_mode_gnome_debian_ubuntu "${disk}" "${mode}"
 			;;
+		debian-kde|ubuntu-kde)
+			configure_display_mode_kde_debian_ubuntu "${disk}" "${mode}"
+			;;
 		fedora-gnome)
 			configure_display_gnome_mode_fedora "${disk}" "${mode}"
 			;;
+		fedora-kde)
+			configure_display_kde_mode_fedora "${disk}" "${mode}"
+			;;
 	esac
 }
-
-configure_display_mode "$VM_IMAGE" "$MODE" "$DISTRO" "$DESKTOP"
 
 echo "Setting up EFI fallback boot entry..."
 case "$DISTRO" in
@@ -137,23 +199,7 @@ virt-customize -a "$VM_IMAGE" \
 		--run-command "mkdir -p /var/lib/systemd/linger" \
 		--run-command "touch /var/lib/systemd/linger/tester"
 
-case "$DESKTOP" in
-	[kK][dD][eE])
-		virt-customize -a "$VM_IMAGE" \
-			--run-command "mkdir -p /etc/sddm.conf.d" \
-			--run-command "printf '[Autologin]\nUser=tester\nSession=plasma\n' > /etc/sddm.conf.d/autologin.conf"
-    ;;
-  *)
-		virt-customize -a "$VM_IMAGE" \
-			--run-command "mkdir -p /etc/dconf/db/local.d" \
-			--run-command "printf '[org/gnome/shell]\ndevelopment-tools=true\n' > /etc/dconf/db/local.d/00-screenshooter" \
-			--run-command "mkdir -p /etc/dconf/profile" \
-			--run-command "printf 'user-db:user\nsystem-db:local\nsystem-db:ibus\n' > /etc/dconf/profile/user" \
-			--run-command "dconf update" \
-			--run-command "sed -i 's/^#\s*AutomaticLoginEnable\s*=.*/AutomaticLoginEnable=true/' /etc/gdm3/daemon.conf" \
-			--run-command "sed -i 's/^#\s*AutomaticLogin\s*=.*/AutomaticLogin=tester/' /etc/gdm3/daemon.conf"
-    ;;
-esac
+configure_display_mode "$VM_IMAGE" "$MODE" "$DISTRO" "$DESKTOP"
 
 if ! virsh net-info default &>/dev/null; then
 	echo "Defining the 'default' network"

--- a/tests/integration/lib/provision-vm.sh
+++ b/tests/integration/lib/provision-vm.sh
@@ -62,7 +62,7 @@ chmod 0664 "$VM_IMAGE"
 chmod 0664 "$VM_IMAGE"
 
 # Configure X11/Wayland mode
-configure_display_mode() {
+configure_display_mode_gnome_debian_ubuntu() {
 	local disk="$1"
 	local mode="$2"
 
@@ -70,17 +70,50 @@ configure_display_mode() {
 		x11)
 			echo "Configuring X11 mode..."
 			virt-customize -a "$disk" \
-				--firstboot-command "sed -i 's/^#*WaylandEnable=.*/WaylandEnable=false/' /etc/gdm3/custom.conf 2>/dev/null || sed -i 's/^#*WaylandEnable=.*/WaylandEnable=false/' /etc/gdm/custom.conf 2>/dev/null || true"
+				--install xserver-xorg \
+				--firstboot-command "sed -i 's/^#*WaylandEnable=.*/WaylandEnable=false/' /etc/gdm3/daemon.conf 2>/dev/null || true" \
+				--firstboot-command "sed -i 's/^#WaylandEnable=false/WaylandEnable=false/' /etc/gdm3/custom.conf 2> /dev/null || true"
 			;;
 		wayland)
-			echo "Configuring Wayland mode..."
-			virt-customize -a "$disk" \
-				--firstboot-command "sed -i 's/^#*WaylandEnable=.*/#WaylandEnable=true/' /etc/gdm3/custom.conf 2>/dev/null || sed -i 's/^#*WaylandEnable=.*/#WaylandEnable=true/' /etc/gdm/custom.conf 2>/dev/null || true"
+			echo "Wayland is the default mode, nothing to do"
 			;;
 	esac
 }
 
-configure_display_mode "$VM_IMAGE" "$MODE"
+configure_display_gnome_mode_fedora() {
+	local disk="$1"
+	local mode="$2"
+
+	case "$mode" in
+		x11)
+			echo "Configuring X11 mode..."
+			virt-customize -a "$disk" \
+				--install xorg-x11-server-Xorg \
+				--firstboot-command "sed -i 's/^#WaylandEnable=false/WaylandEnable=false/' /etc/gdm/custom.conf || true"
+			;;
+		wayland)
+			echo "Wayland is the default mode, nothing to do"
+			;;
+	esac
+}
+
+configure_display_mode() {
+	local disk="$1"
+	local mode="$2"
+	local distro="$3"
+	local desktop="$4"
+
+	case "${distro}-${desktop}" in
+		debian-gnome|ubuntu-gnome)
+			configure_display_mode_gnome_debian_ubuntu "${disk}" "${mode}"
+			;;
+		fedora-gnome)
+			configure_display_gnome_mode_fedora "${disk}" "${mode}"
+			;;
+	esac
+}
+
+configure_display_mode "$VM_IMAGE" "$MODE" "$DISTRO" "$DESKTOP"
 
 echo "Setting up EFI fallback boot entry..."
 case "$DISTRO" in
@@ -100,7 +133,27 @@ virt-customize -a "$VM_IMAGE" \
     --run-command "cp ${EFI_SRC} /boot/efi/EFI/BOOT/bootx64.efi" \
     --install sudo \
 		--run-command "echo 'tester ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/tester" \
-		--run-command "chmod 440 /etc/sudoers.d/tester"
+		--run-command "chmod 440 /etc/sudoers.d/tester" \
+		--run-command "mkdir -p /var/lib/systemd/linger" \
+		--run-command "touch /var/lib/systemd/linger/tester"
+
+case "$DESKTOP" in
+	[kK][dD][eE])
+		virt-customize -a "$VM_IMAGE" \
+			--run-command "mkdir -p /etc/sddm.conf.d" \
+			--run-command "printf '[Autologin]\nUser=tester\nSession=plasma\n' > /etc/sddm.conf.d/autologin.conf"
+    ;;
+  *)
+		virt-customize -a "$VM_IMAGE" \
+			--run-command "mkdir -p /etc/dconf/db/local.d" \
+			--run-command "printf '[org/gnome/shell]\ndevelopment-tools=true\n' > /etc/dconf/db/local.d/00-screenshooter" \
+			--run-command "mkdir -p /etc/dconf/profile" \
+			--run-command "printf 'user-db:user\nsystem-db:local\nsystem-db:ibus\n' > /etc/dconf/profile/user" \
+			--run-command "dconf update" \
+			--run-command "sed -i 's/^#\s*AutomaticLoginEnable\s*=.*/AutomaticLoginEnable=true/' /etc/gdm3/daemon.conf" \
+			--run-command "sed -i 's/^#\s*AutomaticLogin\s*=.*/AutomaticLogin=tester/' /etc/gdm3/daemon.conf"
+    ;;
+esac
 
 if ! virsh net-info default &>/dev/null; then
 	echo "Defining the 'default' network"

--- a/tests/integration/lib/test-mcp.sh
+++ b/tests/integration/lib/test-mcp.sh
@@ -103,15 +103,16 @@ esac
 echo "  OK"
 
 echo "[6/8] Starting MCP server..."
-case "$DISTRO" in
-	debian|ubuntu)
-		run_on_vm "sudo systemctl start screenshooter-mcp || true"
-		;;
-	fedora)
-		run_on_vm "sudo systemctl start screenshooter-mcp || true"
-		;;
-esac
-sleep 2
+run_on_vm "systemctl --user daemon-reload"
+run_on_vm "systemctl --user enable --now screenshooter-mcp.service"
+sleep 3
+run_on_vm "systemctl --user is-active screenshooter-mcp.service" || {
+	echo "ERROR: MCP server failed to start"
+	run_on_vm "systemctl --user status screenshooter-mcp.service" || true
+	run_on_vm "journalctl --user -u screenshooter-mcp --no-pager -n 20" || true
+	exit 1
+}
+echo "  OK"
 
 echo "[7/8] Running MCP tools test..."
 # Run test-mcp inside VM

--- a/tests/integration/lib/test-mcp.sh
+++ b/tests/integration/lib/test-mcp.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Main test orchestrator
+# Usage: ./test-mcp.sh <vm-ip> <distro> <version> <desktop> <mode>
+#
+# This script runs inside the VM via SSH and coordinates all tests.
+
+set -e
+
+VM_IP="$1"
+DISTRO="$2"
+VERSION="$3"
+DESKTOP="$4"
+MODE="$5"
+
+if [ -z "$VM_IP" ] || [ -z "$DISTRO" ] || [ -z "$VERSION" ] || [ -z "$DESKTOP" ] || [ -z "$MODE" ]; then
+	echo "Usage: $0 <vm-ip> <distro> <version> <desktop> <mode>"
+	exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KEYS_DIR="$(cd "$SCRIPT_DIR/../keys" && pwd)"
+PKG_DIR="$(cd "$SCRIPT_DIR/../pkg" && pwd)"
+OUTPUT_DIR="/tmp/screenshooter-mcp-images"
+SSH_OPTS="-o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i ${KEYS_DIR}/test-key"
+SSH="ssh $SSH_OPTS tester@${VM_IP}"
+SCP="scp $SSH_OPTS"
+
+echo "=== ScreenshooterMCP Integration Test ==="
+echo "  VM: $VM_IP"
+echo "  Distro: $DISTRO $VERSION ($DESKTOP)"
+echo "  Mode: $MODE"
+echo ""
+
+# Function to run command on VM
+run_on_vm() {
+	$SSH "$@"
+}
+
+# Function to copy file to VM
+copy_to_vm() {
+	local src="$1"
+	local dest="$2"
+	$SCP "$src" "tester@${VM_IP}:${dest}"
+}
+
+# Function to copy file from VM
+copy_from_vm() {
+	local src="$1"
+	local dest="$2"
+	$SCP "tester@${VM_IP}:${src}" "$dest"
+}
+
+echo "[1/8] Waiting for VM to be ready..."
+if ! $SSH "echo ok" 2>/dev/null | grep -q ok; then
+	echo "ERROR: Cannot SSH to VM"
+	exit 1
+fi
+echo "  OK"
+
+echo "[2/8] Creating output directory..."
+run_on_vm "mkdir -p $OUTPUT_DIR"
+
+echo "[3/8] Uploading test tool..."
+TEST_MCP="${SCRIPT_DIR}/../shared/test-mcp/test-mcp"
+if [ ! -f "$TEST_MCP" ]; then
+	echo "ERROR: test-mcp binary not found at $TEST_MCP"
+	echo "Run: cd shared/test-mcp && go build -o test-mcp ."
+	exit 1
+fi
+copy_to_vm "$TEST_MCP" "/tmp/test-mcp"
+run_on_vm "chmod +x /tmp/test-mcp"
+
+echo "[4/8] Uploading package..."
+case "$DISTRO" in
+	debian|ubuntu)
+		PKG_FILE=$(ls "$PKG_DIR"/screenshooter-mcp-server_*.deb 2>/dev/null | head -1)
+		;;
+	fedora)
+		PKG_FILE=$(ls "$PKG_DIR"/screenshooter-mcp-server-*.rpm 2>/dev/null | head -1)
+		;;
+esac
+
+if [ -z "$PKG_FILE" ]; then
+	echo "ERROR: Package not found in $PKG_DIR"
+	echo "Run: ./lib/download-package.sh $DISTRO"
+	exit 1
+fi
+
+copy_to_vm "$PKG_FILE" "/tmp/package.deb"
+echo "  Package: $(basename "$PKG_FILE")"
+
+echo "[5/8] Installing package..."
+case "$DISTRO" in
+	debian|ubuntu)
+		run_on_vm "sudo dpkg -i /tmp/package.deb"
+		run_on_vm "dpkg -l screenshooter-mcp-server | grep screenshooter"
+		;;
+	fedora)
+		run_on_vm "sudo rpm -ivh /tmp/package.deb"
+		run_on_vm "rpm -q screenshooter-mcp-server"
+		;;
+esac
+echo "  OK"
+
+echo "[6/8] Starting MCP server..."
+case "$DISTRO" in
+	debian|ubuntu)
+		run_on_vm "sudo systemctl start screenshooter-mcp || true"
+		;;
+	fedora)
+		run_on_vm "sudo systemctl start screenshooter-mcp || true"
+		;;
+esac
+sleep 2
+
+echo "[7/8] Running MCP tools test..."
+# Run test-mcp inside VM
+run_on_vm "OUTPUT_DIR=$OUTPUT_DIR /tmp/test-mcp http://localhost:11777" || {
+	echo "ERROR: test-mcp failed"
+	exit 1
+}
+echo "  OK"
+
+echo "[8/8] Downloading results..."
+IMAGES_DIR="${SCRIPT_DIR}/../images/${DISTRO}-${VERSION}-${DESKTOP}-${MODE}"
+mkdir -p "$IMAGES_DIR"
+run_on_vm "ls -la $OUTPUT_DIR/"
+run_on_vm "cd $OUTPUT_DIR && for f in *; do echo \"\$f\"; done" | while read -r f; do
+	if [ -n "$f" ] && [ "$f" != "*" ]; then
+		copy_from_vm "$OUTPUT_DIR/$f" "$IMAGES_DIR/$f"
+	fi
+done
+echo "  Images saved to: $IMAGES_DIR"
+
+echo ""
+echo "=== Test Completed Successfully ==="
+echo "Results: $IMAGES_DIR"

--- a/tests/integration/lib/vm-lifecycle.sh
+++ b/tests/integration/lib/vm-lifecycle.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# VM lifecycle management helpers
+# Usage: ./vm-lifecycle.sh <command> [vm-name]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VMS_DIR="$(cd "$SCRIPT_DIR/../vms" && pwd)"
+KEYS_DIR="$(cd "$SCRIPT_DIR/../keys" && pwd)"
+
+COMMAND="$1"
+VM_NAME="$2"
+
+get_vm_ip() {
+	local vm="$1"
+	local ip_file="${VMS_DIR}/${vm}.ip"
+	local ip
+
+	if [ -f "$ip_file" ]; then
+		ip=$(cat "$ip_file")
+	else
+		ip=$(virsh domifaddr "$vm" 2>/dev/null | grep ipv4 | head -n 1 | awk '{ print $4 }' | sed 's,/.*$,,')
+	fi
+
+	echo "$ip"
+}
+
+ssh_vm() {
+	local vm="$1"
+	shift
+	local ip
+	ip=$(get_vm_ip "$vm")
+
+	if [ -z "$ip" ]; then
+		echo "Cannot determine VM IP for $vm"
+		return 1
+	fi
+
+	ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i "${KEYS_DIR}/test-key" "tester@${ip}" "$@"
+}
+
+scp_to_vm() {
+	local vm="$1"
+	local src="$2"
+	shift 2
+	local ip
+	ip=$(get_vm_ip "$vm")
+
+	if [ -z "$ip" ]; then
+		echo "Cannot determine VM IP for $vm"
+		return 1
+	fi
+
+	scp -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i "${KEYS_DIR}/test-key" "$src" "tester@${ip}:$@"
+}
+
+scp_from_vm() {
+	local vm="$1"
+	shift
+	local ip
+	ip=$(get_vm_ip "$vm")
+
+	if [ -z "$ip" ]; then
+		echo "Cannot determine VM IP for $vm"
+		return 1
+	fi
+
+	scp -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i "${KEYS_DIR}/test-key" "tester@${ip}:$@"
+}
+
+destroy_vm() {
+	local vm="$1"
+
+	echo "Destroying VM: $vm"
+	virsh destroy "$vm" 2>/dev/null || true
+
+	local vm_image="${VMS_DIR}/${vm}.qcow2"
+	if [ -f "$vm_image" ]; then
+		echo "Removing VM image: $vm_image"
+		rm -f "$vm_image"
+	fi
+
+	rm -f "${VMS_DIR}/${vm}.ip" "${VMS_DIR}/${vm}.env"
+
+	virsh undefine "$vm" 2>/dev/null || true
+}
+
+start_vm() {
+	local vm="$1"
+
+	echo "Starting VM: $vm"
+	virsh start "$vm"
+
+	local ip
+	ip=$(get_vm_ip "$vm")
+
+	if [ -z "$ip" ]; then
+		echo "Waiting for IP..."
+		sleep 10
+		ip=$(get_vm_ip "$vm")
+	fi
+
+	echo "VM IP: $ip"
+}
+
+stop_vm() {
+	local vm="$1"
+
+	echo "Stopping VM: $vm"
+	virsh shutdown "$vm" 2>/dev/null || virsh destroy "$vm" 2>/dev/null || true
+}
+
+wait_for_ssh() {
+	local vm="$1"
+	local timeout="${2:-300}"
+	local count=0
+
+	while [ $count -lt $timeout ]; do
+		local ip
+		ip=$(get_vm_ip "$vm")
+
+		if [ -n "$ip" ]; then
+			if ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ConnectTimeout=5 -i "${KEYS_DIR}/test-key" "tester@${ip}" "echo ok" 2>/dev/null | grep -q ok; then
+				echo "SSH ready at $ip"
+				return 0
+			fi
+		fi
+
+		sleep 5
+		count=$((count + 5))
+	done
+
+	echo "SSH did not become ready within ${timeout}s"
+	return 1
+}
+
+case "$COMMAND" in
+	destroy)
+		if [ -z "$VM_NAME" ]; then
+			echo "Usage: $0 destroy <vm-name>"
+			exit 1
+		fi
+		destroy_vm "$VM_NAME"
+		;;
+	start)
+		if [ -z "$VM_NAME" ]; then
+			echo "Usage: $0 start <vm-name>"
+			exit 1
+		fi
+		start_vm "$VM_NAME"
+		;;
+	stop)
+		if [ -z "$VM_NAME" ]; then
+			echo "Usage: $0 stop <vm-name>"
+			exit 1
+		fi
+		stop_vm "$VM_NAME"
+		;;
+	ssh)
+		if [ -z "$VM_NAME" ]; then
+			echo "Usage: $0 ssh <vm-name> <command>"
+			exit 1
+		fi
+		shift 2
+		ssh_vm "$VM_NAME" "$@"
+		;;
+	scp-to)
+		if [ -z "$VM_NAME" ]; then
+			echo "Usage: $0 scp-to <vm-name> <source> <dest>"
+			exit 1
+		fi
+		shift 2
+		scp_to_vm "$VM_NAME" "$@"
+		;;
+	scp-from)
+		if [ -z "$VM_NAME" ]; then
+			echo "Usage: $0 scp-from <vm-name> <source> <dest>"
+			exit 1
+		fi
+		shift 2
+		scp_from_vm "$VM_NAME" "$@"
+		;;
+	wait-ssh)
+		if [ -z "$VM_NAME" ]; then
+			echo "Usage: $0 wait-ssh <vm-name> [timeout]"
+			exit 1
+		fi
+		wait_for_ssh "$VM_NAME" "${3:-300}"
+		;;
+	ip)
+		if [ -z "$VM_NAME" ]; then
+			echo "Usage: $0 ip <vm-name>"
+			exit 1
+		fi
+		get_vm_ip "$VM_NAME"
+		;;
+	list)
+		echo "Available VMs:"
+		virsh list --all --name 2>/dev/null | grep test- || echo "  (none)"
+		;;
+	*)
+		echo "Usage: $0 <command> [args]"
+		echo ""
+		echo "Commands:"
+		echo "  destroy <vm-name>	 Destroy VM and remove image"
+		echo "  start <vm-name>	   Start a stopped VM"
+		echo "  stop <vm-name>		Stop a running VM"
+		echo "  ssh <vm-name> <cmd>   Run command via SSH"
+		echo "  scp-to <vm-name> <src> <dest>  Copy file to VM"
+		echo "  scp-from <vm-name> <src> <dest>  Copy file from VM"
+		echo "  wait-ssh <vm-name> [timeout]  Wait for SSH to be ready"
+		echo "  ip <vm-name>		  Get VM IP address"
+		echo "  list				  List all test VMs"
+		;;
+esac

--- a/tests/integration/lib/vm-lifecycle.sh
+++ b/tests/integration/lib/vm-lifecycle.sh
@@ -8,6 +8,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VMS_DIR="$(cd "$SCRIPT_DIR/../vms" && pwd)"
 KEYS_DIR="$(cd "$SCRIPT_DIR/../keys" && pwd)"
 
+# this is required if we want to enable networking on our VMs ; and it shall be used
+# through all operations, including virt-install and so on.
+export LIBVIRT_DEFAULT_URI=qemu:///system
+
 COMMAND="$1"
 VM_NAME="$2"
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -83,6 +83,13 @@ case "$DESKTOP" in
 		;;
 esac
 
+case "${DISTRO}-${VERSION}-${DESKTOP}-${MODE}" in
+	fedora-43-gnome-x11|fedora-43-kde-x11)
+		echo "Unsupported combination: ${DISTRO}, ${VERSION}, ${DESKTOP}, ${MODE}, ignoring"
+		exit 0
+		;;
+esac
+
 VM_NAME="test-${DISTRO}-${VERSION}-${DESKTOP}-${MODE}"
 BASE_IMAGE="${BASES_DIR}/${DISTRO}-${VERSION}-${DESKTOP}.qcow2"
 VM_IMAGE="${VMS_DIR}/${VM_NAME}.qcow2"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Main test runner for ScreenshooterMCP integration tests
+# Usage: ./run.sh <distro> <version> <desktop> <mode> [--keep-running]
+#
+# Supported distributions:
+#   - debian: 12, 13
+#   - ubuntu: 24.04, 25.10, 26.04
+#   - fedora: 42, 43
+#
+# Supported desktops: gnome, kde
+# Supported modes: x11, wayland
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/lib"
+KEYS_DIR="$SCRIPT_DIR/keys"
+BASES_DIR="$SCRIPT_DIR/bases"
+VMS_DIR="$SCRIPT_DIR/vms"
+IMAGES_DIR="$SCRIPT_DIR/images"
+SHARED_DIR="$SCRIPT_DIR/shared"
+PKG_DIR="$SCRIPT_DIR/pkg"
+
+# this is required if we want to enable networking on our VMs ; and it shall be used
+# through all operations, including virt-install and so on.
+export LIBVIRT_DEFAULT_URI=qemu:///system
+
+DISTRO="$1"
+VERSION="$2"
+DESKTOP="$3"
+MODE="$4"
+KEEP_RUNNING=false
+
+for arg in "$@"; do
+	case "$arg" in
+		--keep-running)
+			KEEP_RUNNING=true
+			;;
+	esac
+done
+
+if [ -z "$DISTRO" ] || [ -z "$VERSION" ] || [ -z "$DESKTOP" ] || [ -z "$MODE" ]; then
+	echo "Usage: $0 <distro> <version> <desktop> <mode> [--keep-running]"
+	echo ""
+	echo "Supported distributions:"
+	echo "  - debian: 12, 13"
+	echo "  - ubuntu: 24.04, 25.10, 26.04"
+	echo "  - fedora: 42, 43"
+	echo ""
+	echo "Supported desktops: gnome, kde"
+	echo "Supported modes: x11, wayland"
+	echo ""
+	echo "Example:"
+	echo "  $0 debian 13 gnome wayland"
+	echo "  $0 ubuntu 24.04 gnome x11 --keep-running"
+	exit 1
+fi
+
+case "$DISTRO" in
+	debian|ubuntu|fedora)
+		;;
+	*)
+		echo "Unsupported distro: $DISTRO"
+		exit 1
+		;;
+esac
+
+case "$MODE" in
+	x11|wayland)
+		;;
+	*)
+		echo "Unsupported mode: $MODE (expected x11 or wayland)"
+		exit 1
+		;;
+esac
+
+case "$DESKTOP" in
+	gnome|kde)
+		;;
+	*)
+		echo "Unsupported desktop: $DESKTOP (expected gnome or kde)"
+		exit 1
+		;;
+esac
+
+VM_NAME="test-${DISTRO}-${VERSION}-${DESKTOP}-${MODE}"
+BASE_IMAGE="${BASES_DIR}/${DISTRO}-${VERSION}-${DESKTOP}.qcow2"
+VM_IMAGE="${VMS_DIR}/${VM_NAME}.qcow2"
+IP_FILE="${VMS_DIR}/${VM_NAME}.ip"
+
+cleanup() {
+	if [ "$KEEP_RUNNING" = true ]; then
+		echo "Keeping VM running (--keep-running specified)"
+		echo "VM name: $VM_NAME"
+		echo "To connect: ./lib/vm-lifecycle.sh ssh $VM_NAME"
+		echo "To destroy: ./lib/vm-lifecycle.sh destroy $VM_NAME"
+		return
+	fi
+
+	echo "Cleaning up VM..."
+	"$LIB_DIR/vm-lifecycle.sh" destroy "$VM_NAME" 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+echo "=== ScreenshooterMCP Integration Test ==="
+echo "  Distribution: $DISTRO $VERSION ($DESKTOP)"
+echo "  Display mode: $MODE"
+echo ""
+
+if [ ! -f "$KEYS_DIR/test-key" ]; then
+	echo "Generating SSH key..."
+	"$LIB_DIR/create-ssh-key.sh"
+fi
+
+echo "[1/8] Checking base image..."
+if [ ! -f "$BASE_IMAGE" ]; then
+	echo "Base image not found: $BASE_IMAGE"
+	echo "Creating base image (this may take a while)..."
+
+	"$LIB_DIR/download-iso.sh" "$DISTRO" "$VERSION" "$DESKTOP"
+	"$LIB_DIR/create-base-image.sh" "$DISTRO" "$VERSION" "$DESKTOP"
+fi
+echo "  Base image ready: $BASE_IMAGE"
+
+echo "[2/8] Provisioning VM..."
+if [ -f "$VM_IMAGE" ]; then
+	echo "Removing existing VM image..."
+	rm -f "$VM_IMAGE"
+fi
+
+"$LIB_DIR/provision-vm.sh" "$DISTRO" "$VERSION" "$DESKTOP" "$MODE"
+echo "  VM provisioned"
+
+echo "[3/8] Waiting for VM to be ready..."
+VM_IP=$(cat "$IP_FILE" 2>/dev/null || "$LIB_DIR/vm-lifecycle.sh" ip "$VM_NAME")
+
+if [ -z "$VM_IP" ]; then
+	echo "ERROR: Could not get VM IP"
+	exit 1
+fi
+echo "  VM IP: $VM_IP"
+
+"$LIB_DIR/vm-lifecycle.sh" wait-ssh "$VM_NAME" 120
+
+echo "[4/8] Building test tool..."
+TEST_MCP="${SHARED_DIR}/test-mcp/test-mcp"
+if [ ! -f "$TEST_MCP" ]; then
+	echo "Building test-mcp..."
+	(cd "${SHARED_DIR}/test-mcp" && go build -o test-mcp .)
+fi
+if [ ! -f "$TEST_MCP" ]; then
+	echo "ERROR: Failed to build test-mcp"
+	exit 1
+fi
+echo "  Test tool ready"
+
+echo "[5/8] Downloading package..."
+"$LIB_DIR/download-package.sh" "$DISTRO"
+
+echo "[6/8] Running test inside VM..."
+"$LIB_DIR/test-mcp.sh" "$VM_IP" "$DISTRO" "$VERSION" "$DESKTOP" "$MODE"
+echo "  Test completed"
+
+echo "[7/8] Verifying results..."
+RESULTS_DIR="${IMAGES_DIR}/${DISTRO}-${VERSION}-${DESKTOP}-${MODE}"
+if [ -d "$RESULTS_DIR" ]; then
+	echo "  Results saved to: $RESULTS_DIR"
+	ls -la "$RESULTS_DIR/"
+else
+	echo "WARNING: No results directory found"
+fi
+
+echo ""
+echo "=== Test Completed ==="
+echo "Results: $RESULTS_DIR"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -5,7 +5,7 @@
 # Supported distributions:
 #   - debian: 12, 13
 #   - ubuntu: 24.04, 25.10, 26.04
-#   - fedora: 42, 43
+#   - fedora: 43
 #
 # Supported desktops: gnome, kde
 # Supported modes: x11, wayland
@@ -45,7 +45,7 @@ if [ -z "$DISTRO" ] || [ -z "$VERSION" ] || [ -z "$DESKTOP" ] || [ -z "$MODE" ];
 	echo "Supported distributions:"
 	echo "  - debian: 12, 13"
 	echo "  - ubuntu: 24.04, 25.10, 26.04"
-	echo "  - fedora: 42, 43"
+	echo "  - fedora: 43"
 	echo ""
 	echo "Supported desktops: gnome, kde"
 	echo "Supported modes: x11, wayland"

--- a/tests/integration/shared/test-mcp/.gitignore
+++ b/tests/integration/shared/test-mcp/.gitignore
@@ -1,0 +1,1 @@
+/test-mcp

--- a/tests/integration/shared/test-mcp/go.mod
+++ b/tests/integration/shared/test-mcp/go.mod
@@ -1,0 +1,3 @@
+module github.com/emmanuel-deloget/screenshooter-mcp/test-mcp
+
+go 1.26.0

--- a/tests/integration/shared/test-mcp/main.go
+++ b/tests/integration/shared/test-mcp/main.go
@@ -4,12 +4,14 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -262,6 +264,11 @@ func callToolRaw(ctx context.Context, client *http.Client, serverURL string, par
 		return nil, fmt.Errorf("unexpected status: %d - %s", resp.StatusCode, string(respBody))
 	}
 
+	contentType := resp.Header.Get("Content-Type")
+	if strings.HasPrefix(contentType, "text/event-stream") {
+		return parseSSEResponse(resp.Body)
+	}
+
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
@@ -282,6 +289,58 @@ func callToolRaw(ctx context.Context, client *http.Client, serverURL string, par
 	}
 
 	return result, nil
+}
+
+func parseSSEResponse(body io.Reader) (map[string]any, error) {
+	scanner := bufio.NewScanner(body)
+	var lastEventData string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, "data:") {
+			lastEventData = strings.TrimPrefix(line, "data:")
+			lastEventData = strings.TrimSpace(lastEventData)
+		}
+
+		if line == "" && lastEventData != "" {
+			var rpcResp JSONRPCResponse
+			if err := json.Unmarshal([]byte(lastEventData), &rpcResp); err != nil {
+				continue
+			}
+
+			if rpcResp.Error != nil {
+				return nil, fmt.Errorf("RPC error: %s", rpcResp.Error.Message)
+			}
+
+			result, ok := rpcResp.Result.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("unexpected result type in SSE")
+			}
+
+			return result, nil
+		}
+	}
+
+	if lastEventData != "" {
+		var rpcResp JSONRPCResponse
+		if err := json.Unmarshal([]byte(lastEventData), &rpcResp); err != nil {
+			return nil, fmt.Errorf("failed to parse SSE data: %w", err)
+		}
+
+		if rpcResp.Error != nil {
+			return nil, fmt.Errorf("RPC error: %s", rpcResp.Error.Message)
+		}
+
+		result, ok := rpcResp.Result.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected result type in SSE")
+		}
+
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("no valid JSON-RPC response found in SSE stream")
 }
 
 func extractImage(result map[string]any) ([]byte, error) {

--- a/tests/integration/shared/test-mcp/main.go
+++ b/tests/integration/shared/test-mcp/main.go
@@ -172,17 +172,11 @@ func (m *MCPServer) initialize(ctx context.Context) error {
 		ID:      1,
 	}
 
-	result, err := m.call(ctx, reqBody)
+	_, err := m.call(ctx, reqBody)
 	if err != nil {
 		return fmt.Errorf("initialize failed: %w", err)
 	}
 
-	if result != nil {
-		resultJSON, _ := json.Marshal(result)
-		fmt.Fprintf(os.Stderr, "Initialized: %s\n", string(resultJSON))
-	}
-
-	m.sessionID = fmt.Sprintf("init-%d", time.Now().UnixNano())
 	m.initialized = true
 
 	notifReq := JSONRPCRequest{
@@ -194,6 +188,8 @@ func (m *MCPServer) initialize(ctx context.Context) error {
 	m.call(ctx, notifReq)
 
 	time.Sleep(100 * time.Millisecond)
+
+	fmt.Fprintf(os.Stderr, "Session ID: %s\n", m.sessionID)
 
 	return nil
 }
@@ -337,9 +333,24 @@ func (m *MCPServer) call(ctx context.Context, req JSONRPCRequest) (map[string]an
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized && !m.initialized {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unauthorized: %s", string(respBody))
+	}
+
+	if resp.StatusCode == http.StatusNotFound && m.sessionID != "" {
+		return nil, fmt.Errorf("session not found: %s", m.sessionID)
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("unexpected status: %d - %s", resp.StatusCode, string(respBody))
+	}
+
+	sessionID := resp.Header.Get("mcp-session-id")
+	if sessionID != "" && m.sessionID == "" {
+		m.sessionID = sessionID
+		fmt.Fprintf(os.Stderr, "Session ID: %s\n", m.sessionID)
 	}
 
 	contentType := resp.Header.Get("Content-Type")

--- a/tests/integration/shared/test-mcp/main.go
+++ b/tests/integration/shared/test-mcp/main.go
@@ -50,10 +50,22 @@ type ClientInfo struct {
 	Version string `json:"version"`
 }
 
+type InitializeResult struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities"`
+	ServerInfo      ServerInfo     `json:"serverInfo"`
+}
+
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
 type MCPServer struct {
-	client   *http.Client
-	serverURL string
-	sessionID string
+	client      *http.Client
+	serverURL  string
+	sessionID  string
+	initialized bool
 }
 
 func main() {
@@ -166,8 +178,12 @@ func (m *MCPServer) initialize(ctx context.Context) error {
 	}
 
 	if result != nil {
-		fmt.Fprintf(os.Stderr, "Initialized: %v\n", result)
+		resultJSON, _ := json.Marshal(result)
+		fmt.Fprintf(os.Stderr, "Initialized: %s\n", string(resultJSON))
 	}
+
+	m.sessionID = fmt.Sprintf("init-%d", time.Now().UnixNano())
+	m.initialized = true
 
 	notifReq := JSONRPCRequest{
 		JSONRPC: "2.0",
@@ -310,6 +326,10 @@ func (m *MCPServer) call(ctx context.Context, req JSONRPCRequest) (map[string]an
 
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+
+	if m.sessionID != "" {
+		httpReq.Header.Set("mcp-session-id", m.sessionID)
+	}
 
 	resp, err := m.client.Do(httpReq)
 	if err != nil {
@@ -465,22 +485,4 @@ func saveImage(ctx context.Context, dir, name string, data []byte) {
 	}
 
 	fmt.Printf("Saved: %s (%d bytes)\n", path, len(data))
-}
-
-type readCloseProxy struct {
-	data []byte
-	pos  int
-}
-
-func (r *readCloseProxy) Read(p []byte) (n int, err error) {
-	if r.pos >= len(r.data) {
-		return 0, io.EOF
-	}
-	n = copy(p, r.data[r.pos:])
-	r.pos += n
-	return n, nil
-}
-
-func (r *readCloseProxy) Close() error {
-	return nil
 }

--- a/tests/integration/shared/test-mcp/main.go
+++ b/tests/integration/shared/test-mcp/main.go
@@ -65,6 +65,11 @@ func main() {
 
 	ctx := context.Background()
 
+	if err := initializeServer(ctx, client, serverURL); err != nil {
+		fmt.Fprintf(os.Stderr, "initialize failed: %v\n", err)
+		os.Exit(1)
+	}
+
 	monitors, err := callListMonitors(ctx, client, serverURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "list_monitors failed: %v\n", err)
@@ -235,7 +240,55 @@ func callToolRaw(ctx context.Context, client *http.Client, serverURL string, par
 		Params:  mustMarshal(params),
 		ID:      1,
 	}
+	return callJSONRPC(ctx, client, serverURL, reqBody)
+}
 
+type InitializeParams struct {
+	ProtocolVersion string `json:"protocolVersion"`
+	Capabilities   map[string]any `json:"capabilities"`
+	ClientInfo     ClientInfo `json:"clientInfo"`
+}
+
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func initializeServer(ctx context.Context, client *http.Client, serverURL string) error {
+	params := InitializeParams{
+		ProtocolVersion: "2024-11-05",
+		Capabilities:  map[string]any{},
+		ClientInfo: ClientInfo{
+			Name:    "test-mcp",
+			Version: "1.0.0",
+		},
+	}
+
+	reqBody := JSONRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "initialize",
+		Params:  mustMarshal(params),
+		ID:      1,
+	}
+
+	result, err := callJSONRPC(ctx, client, serverURL, reqBody)
+	if err != nil {
+		return fmt.Errorf("initialize failed: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Initialized: %v\n", result)
+
+	notifReq := JSONRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	}
+
+	_, _ = callJSONRPC(ctx, client, serverURL, notifReq)
+
+	return nil
+}
+
+func callJSONRPC(ctx context.Context, client *http.Client, serverURL string, reqBody JSONRPCRequest) (map[string]any, error) {
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)

--- a/tests/integration/shared/test-mcp/main.go
+++ b/tests/integration/shared/test-mcp/main.go
@@ -1,0 +1,369 @@
+// Copyright 2025 Emmanuel Deloget. All rights reserved.
+// Use of this source code is governed by the license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+type JSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	ID      any             `json:"id"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string        `json:"jsonrpc"`
+	Result  any           `json:"result,omitempty"`
+	Error   *JSONRPCError `json:"error,omitempty"`
+	ID      any           `json:"id"`
+}
+
+type JSONRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type ToolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+type MCPResponse struct {
+	Content []map[string]any `json:"content"`
+	IsError bool             `json:"isError"`
+}
+
+func main() {
+	serverURL := os.Getenv("SERVER_URL")
+	if serverURL == "" {
+		serverURL = "http://localhost:11777"
+	}
+
+	outputDir := os.Getenv("OUTPUT_DIR")
+	if outputDir == "" {
+		outputDir = "/tmp/screenshooter-mcp-images"
+	}
+
+	if len(os.Args) > 1 {
+		serverURL = os.Args[1]
+	}
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	ctx := context.Background()
+
+	monitors, err := callListMonitors(ctx, client, serverURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "list_monitors failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	saveJSON(ctx, outputDir, "list_monitors.json", monitors)
+
+	windows, err := callListWindows(ctx, client, serverURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "list_windows failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	saveJSON(ctx, outputDir, "list_windows.json", windows)
+
+	imgData, err := callCaptureScreen(ctx, client, serverURL, "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "capture_screen failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	saveImage(ctx, outputDir, "capture_screen.png", imgData)
+
+	if len(monitors) > 0 {
+		firstMonitor := monitors[0]
+		if name, ok := firstMonitor["Name"].(string); ok {
+			imgData, err := callCaptureScreen(ctx, client, serverURL, name)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "capture_screen (monitor %s) failed: %v\n", name, err)
+				os.Exit(1)
+			}
+			saveImage(ctx, outputDir, "capture_screen-"+name+".png", imgData)
+		}
+	}
+
+	if len(windows) > 0 {
+		firstWindow := windows[0]
+		if title, ok := firstWindow["Title"].(string); ok {
+			imgData, err := callCaptureWindow(ctx, client, serverURL, title)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "capture_window (title %s) failed: %v\n", title, err)
+				os.Exit(1)
+			}
+			saveImage(ctx, outputDir, "capture_window-"+title+".png", imgData)
+		}
+	}
+
+	imgData, err = callCaptureRegion(ctx, client, serverURL, 0, 0, 800, 600)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "capture_region failed: %v\n", err)
+		os.Exit(1)
+	}
+	saveImage(ctx, outputDir, "capture_region.png", imgData)
+
+	fmt.Println("All tests passed!")
+}
+
+func callListMonitors(ctx context.Context, client *http.Client, serverURL string) ([]map[string]any, error) {
+	params := ToolCallParams{
+		Name: "list_monitors",
+	}
+	return callTool(ctx, client, serverURL, params)
+}
+
+func callListWindows(ctx context.Context, client *http.Client, serverURL string) ([]map[string]any, error) {
+	params := ToolCallParams{
+		Name: "list_windows",
+	}
+	return callTool(ctx, client, serverURL, params)
+}
+
+func callCaptureScreen(ctx context.Context, client *http.Client, serverURL, monitor string) ([]byte, error) {
+	args := map[string]any{}
+	if monitor != "" {
+		args["monitor"] = monitor
+	}
+
+	params := ToolCallParams{
+		Name:      "capture_screen",
+		Arguments: mustMarshal(args),
+	}
+
+	result, err := callToolRaw(ctx, client, serverURL, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractImage(result)
+}
+
+func callCaptureWindow(ctx context.Context, client *http.Client, serverURL, title string) ([]byte, error) {
+	args := map[string]any{
+		"title": title,
+	}
+
+	params := ToolCallParams{
+		Name:      "capture_window",
+		Arguments: mustMarshal(args),
+	}
+
+	result, err := callToolRaw(ctx, client, serverURL, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractImage(result)
+}
+
+func callCaptureRegion(ctx context.Context, client *http.Client, serverURL string, x, y, w, h int) ([]byte, error) {
+	args := map[string]any{
+		"x":      x,
+		"y":      y,
+		"width":  w,
+		"height": h,
+	}
+
+	params := ToolCallParams{
+		Name:      "capture_region",
+		Arguments: mustMarshal(args),
+	}
+
+	result, err := callToolRaw(ctx, client, serverURL, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractImage(result)
+}
+
+func callTool(ctx context.Context, client *http.Client, serverURL string, params ToolCallParams) ([]map[string]any, error) {
+	result, err := callToolRaw(ctx, client, serverURL, params)
+	if err != nil {
+		return nil, err
+	}
+
+	data, ok := result["content"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected result format")
+	}
+
+	if len(data) == 0 {
+		return []map[string]any{}, nil
+	}
+
+	first, ok := data[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected content format")
+	}
+
+	text, ok := first["text"].(string)
+	if !ok {
+		return nil, fmt.Errorf("expected text content")
+	}
+
+	var parsed []map[string]any
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	return parsed, nil
+}
+
+func callToolRaw(ctx context.Context, client *http.Client, serverURL string, params ToolCallParams) (map[string]any, error) {
+	reqBody := JSONRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  mustMarshal(params),
+		ID:      1,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", serverURL, io.NopCloser(
+		io.NopCloser(
+			&readCloseProxy{data: body},
+		),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status: %d - %s", resp.StatusCode, string(respBody))
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var rpcResp JSONRPCResponse
+	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("RPC error: %s", rpcResp.Error.Message)
+	}
+
+	result, ok := rpcResp.Result.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected result type")
+	}
+
+	return result, nil
+}
+
+func extractImage(result map[string]any) ([]byte, error) {
+	content, ok := result["content"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("no content in result")
+	}
+
+	if len(content) == 0 {
+		return nil, fmt.Errorf("empty content")
+	}
+
+	first, ok := content[0].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected content type")
+	}
+
+	data, ok := first["data"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("no data field")
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty data array")
+	}
+
+	dataStr, ok := data[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("expected string data")
+	}
+
+	return []byte(dataStr), nil
+}
+
+func mustMarshal(v any) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func saveJSON(ctx context.Context, dir, name string, data any) {
+	content, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal %s: %v\n", name, err)
+		return
+	}
+
+	path := dir + "/" + name
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", path, err)
+		return
+	}
+
+	fmt.Printf("Saved: %s\n", path)
+}
+
+func saveImage(ctx context.Context, dir, name string, data []byte) {
+	path := dir + "/" + name
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", path, err)
+		return
+	}
+
+	fmt.Printf("Saved: %s (%d bytes)\n", path, len(data))
+}
+
+type readCloseProxy struct {
+	data []byte
+	pos  int
+}
+
+func (r *readCloseProxy) Read(p []byte) (n int, err error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n = copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func (r *readCloseProxy) Close() error {
+	return nil
+}

--- a/tests/integration/shared/test-mcp/main.go
+++ b/tests/integration/shared/test-mcp/main.go
@@ -64,8 +64,8 @@ type ServerInfo struct {
 
 type MCPServer struct {
 	client      *http.Client
-	serverURL  string
-	sessionID  string
+	serverURL   string
+	sessionID   string
 	initialized bool
 }
 
@@ -159,7 +159,7 @@ func main() {
 func (m *MCPServer) initialize(ctx context.Context) error {
 	params := InitializeParams{
 		ProtocolVersion: "2024-11-05",
-		Capabilities:  map[string]any{},
+		Capabilities:    map[string]any{},
 		ClientInfo: ClientInfo{
 			Name:    "test-mcp",
 			Version: "1.0.0",
@@ -383,39 +383,22 @@ func (m *MCPServer) call(ctx context.Context, req JSONRPCRequest) (map[string]an
 
 func parseSSEResponse(body io.Reader) (map[string]any, error) {
 	scanner := bufio.NewScanner(body)
-	var lastEventData string
+	buf := make([]byte, 256*1024)
+	scanner.Buffer(buf, 10*1024*1024)
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	var dataBuf strings.Builder
 
-		if strings.HasPrefix(line, "data:") {
-			lastEventData = strings.TrimPrefix(line, "data:")
-			lastEventData = strings.TrimSpace(lastEventData)
+	flush := func() (map[string]any, error) {
+		if dataBuf.Len() == 0 {
+			return nil, nil
 		}
 
-		if line == "" && lastEventData != "" {
-			var rpcResp JSONRPCResponse
-			if err := json.Unmarshal([]byte(lastEventData), &rpcResp); err != nil {
-				continue
-			}
+		raw := dataBuf.String()
+		dataBuf.Reset()
 
-			if rpcResp.Error != nil {
-				return nil, fmt.Errorf("RPC error: %s", rpcResp.Error.Message)
-			}
-
-			result, ok := rpcResp.Result.(map[string]any)
-			if !ok {
-				return nil, fmt.Errorf("unexpected result type in SSE")
-			}
-
-			return result, nil
-		}
-	}
-
-	if lastEventData != "" {
 		var rpcResp JSONRPCResponse
-		if err := json.Unmarshal([]byte(lastEventData), &rpcResp); err != nil {
-			return nil, fmt.Errorf("failed to parse SSE data: %w", err)
+		if err := json.Unmarshal([]byte(raw), &rpcResp); err != nil {
+			return nil, err
 		}
 
 		if rpcResp.Error != nil {
@@ -430,7 +413,30 @@ func parseSSEResponse(body io.Reader) (map[string]any, error) {
 		return result, nil
 	}
 
-	return nil, fmt.Errorf("no valid JSON-RPC response found in SSE stream")
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			continue
+
+		case strings.HasPrefix(line, "data:"):
+			data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			dataBuf.WriteString(data)
+
+		case line == "":
+			res, err := flush()
+			if err != nil {
+				return nil, err
+			}
+			if res != nil {
+				return res, nil
+			}
+		}
+	}
+
+	// flush final
+	return flush()
 }
 
 func extractImage(result map[string]any) ([]byte, error) {

--- a/tests/integration/shared/test-mcp/main.go
+++ b/tests/integration/shared/test-mcp/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -447,21 +448,37 @@ func extractImage(result map[string]any) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected content type")
 	}
 
-	data, ok := first["data"].([]any)
+	dataField, ok := first["data"]
 	if !ok {
 		return nil, fmt.Errorf("no data field")
 	}
 
-	if len(data) == 0 {
-		return nil, fmt.Errorf("empty data array")
+	var dataBytes []byte
+	switch v := dataField.(type) {
+	case string:
+		var err error
+		dataBytes, err = decoding(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode base64: %w", err)
+		}
+	case []any:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("empty data array")
+		}
+		dataStr, ok := v[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string data")
+		}
+		dataBytes = []byte(dataStr)
+	default:
+		return nil, fmt.Errorf("unexpected data type: %T", dataField)
 	}
 
-	dataStr, ok := data[0].(string)
-	if !ok {
-		return nil, fmt.Errorf("expected string data")
-	}
+	return dataBytes, nil
+}
 
-	return []byte(dataStr), nil
+func decoding(s string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(s)
 }
 
 func mustMarshal(v any) json.RawMessage {

--- a/tests/integration/shared/test-mcp/main.go
+++ b/tests/integration/shared/test-mcp/main.go
@@ -39,9 +39,21 @@ type ToolCallParams struct {
 	Arguments json.RawMessage `json:"arguments,omitempty"`
 }
 
-type MCPResponse struct {
-	Content []map[string]any `json:"content"`
-	IsError bool             `json:"isError"`
+type InitializeParams struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities"`
+	ClientInfo      ClientInfo     `json:"clientInfo"`
+}
+
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type MCPServer struct {
+	client   *http.Client
+	serverURL string
+	sessionID string
 }
 
 func main() {
@@ -59,18 +71,21 @@ func main() {
 		serverURL = os.Args[1]
 	}
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
 	ctx := context.Background()
 
-	if err := initializeServer(ctx, client, serverURL); err != nil {
+	mcp := &MCPServer{
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		serverURL: serverURL,
+	}
+
+	if err := mcp.initialize(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "initialize failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	monitors, err := callListMonitors(ctx, client, serverURL)
+	monitors, err := mcp.listMonitors(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "list_monitors failed: %v\n", err)
 		os.Exit(1)
@@ -78,7 +93,7 @@ func main() {
 
 	saveJSON(ctx, outputDir, "list_monitors.json", monitors)
 
-	windows, err := callListWindows(ctx, client, serverURL)
+	windows, err := mcp.listWindows(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "list_windows failed: %v\n", err)
 		os.Exit(1)
@@ -86,7 +101,7 @@ func main() {
 
 	saveJSON(ctx, outputDir, "list_windows.json", windows)
 
-	imgData, err := callCaptureScreen(ctx, client, serverURL, "")
+	imgData, err := mcp.captureScreen(ctx, "")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "capture_screen failed: %v\n", err)
 		os.Exit(1)
@@ -97,7 +112,7 @@ func main() {
 	if len(monitors) > 0 {
 		firstMonitor := monitors[0]
 		if name, ok := firstMonitor["Name"].(string); ok {
-			imgData, err := callCaptureScreen(ctx, client, serverURL, name)
+			imgData, err := mcp.captureScreen(ctx, name)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "capture_screen (monitor %s) failed: %v\n", name, err)
 				os.Exit(1)
@@ -109,7 +124,7 @@ func main() {
 	if len(windows) > 0 {
 		firstWindow := windows[0]
 		if title, ok := firstWindow["Title"].(string); ok {
-			imgData, err := callCaptureWindow(ctx, client, serverURL, title)
+			imgData, err := mcp.captureWindow(ctx, title)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "capture_window (title %s) failed: %v\n", title, err)
 				os.Exit(1)
@@ -118,7 +133,7 @@ func main() {
 		}
 	}
 
-	imgData, err = callCaptureRegion(ctx, client, serverURL, 0, 0, 800, 600)
+	imgData, err = mcp.captureRegion(ctx, 0, 0, 800, 600)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "capture_region failed: %v\n", err)
 		os.Exit(1)
@@ -128,21 +143,60 @@ func main() {
 	fmt.Println("All tests passed!")
 }
 
-func callListMonitors(ctx context.Context, client *http.Client, serverURL string) ([]map[string]any, error) {
+func (m *MCPServer) initialize(ctx context.Context) error {
+	params := InitializeParams{
+		ProtocolVersion: "2024-11-05",
+		Capabilities:  map[string]any{},
+		ClientInfo: ClientInfo{
+			Name:    "test-mcp",
+			Version: "1.0.0",
+		},
+	}
+
+	reqBody := JSONRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "initialize",
+		Params:  mustMarshal(params),
+		ID:      1,
+	}
+
+	result, err := m.call(ctx, reqBody)
+	if err != nil {
+		return fmt.Errorf("initialize failed: %w", err)
+	}
+
+	if result != nil {
+		fmt.Fprintf(os.Stderr, "Initialized: %v\n", result)
+	}
+
+	notifReq := JSONRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+		ID:      2,
+	}
+
+	m.call(ctx, notifReq)
+
+	time.Sleep(100 * time.Millisecond)
+
+	return nil
+}
+
+func (m *MCPServer) listMonitors(ctx context.Context) ([]map[string]any, error) {
 	params := ToolCallParams{
 		Name: "list_monitors",
 	}
-	return callTool(ctx, client, serverURL, params)
+	return m.callTool(ctx, params)
 }
 
-func callListWindows(ctx context.Context, client *http.Client, serverURL string) ([]map[string]any, error) {
+func (m *MCPServer) listWindows(ctx context.Context) ([]map[string]any, error) {
 	params := ToolCallParams{
 		Name: "list_windows",
 	}
-	return callTool(ctx, client, serverURL, params)
+	return m.callTool(ctx, params)
 }
 
-func callCaptureScreen(ctx context.Context, client *http.Client, serverURL, monitor string) ([]byte, error) {
+func (m *MCPServer) captureScreen(ctx context.Context, monitor string) ([]byte, error) {
 	args := map[string]any{}
 	if monitor != "" {
 		args["monitor"] = monitor
@@ -153,7 +207,7 @@ func callCaptureScreen(ctx context.Context, client *http.Client, serverURL, moni
 		Arguments: mustMarshal(args),
 	}
 
-	result, err := callToolRaw(ctx, client, serverURL, params)
+	result, err := m.callToolRaw(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +215,7 @@ func callCaptureScreen(ctx context.Context, client *http.Client, serverURL, moni
 	return extractImage(result)
 }
 
-func callCaptureWindow(ctx context.Context, client *http.Client, serverURL, title string) ([]byte, error) {
+func (m *MCPServer) captureWindow(ctx context.Context, title string) ([]byte, error) {
 	args := map[string]any{
 		"title": title,
 	}
@@ -171,7 +225,7 @@ func callCaptureWindow(ctx context.Context, client *http.Client, serverURL, titl
 		Arguments: mustMarshal(args),
 	}
 
-	result, err := callToolRaw(ctx, client, serverURL, params)
+	result, err := m.callToolRaw(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +233,7 @@ func callCaptureWindow(ctx context.Context, client *http.Client, serverURL, titl
 	return extractImage(result)
 }
 
-func callCaptureRegion(ctx context.Context, client *http.Client, serverURL string, x, y, w, h int) ([]byte, error) {
+func (m *MCPServer) captureRegion(ctx context.Context, x, y, w, h int) ([]byte, error) {
 	args := map[string]any{
 		"x":      x,
 		"y":      y,
@@ -192,7 +246,7 @@ func callCaptureRegion(ctx context.Context, client *http.Client, serverURL strin
 		Arguments: mustMarshal(args),
 	}
 
-	result, err := callToolRaw(ctx, client, serverURL, params)
+	result, err := m.callToolRaw(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -200,8 +254,8 @@ func callCaptureRegion(ctx context.Context, client *http.Client, serverURL strin
 	return extractImage(result)
 }
 
-func callTool(ctx context.Context, client *http.Client, serverURL string, params ToolCallParams) ([]map[string]any, error) {
-	result, err := callToolRaw(ctx, client, serverURL, params)
+func (m *MCPServer) callTool(ctx context.Context, params ToolCallParams) ([]map[string]any, error) {
+	result, err := m.callToolRaw(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -233,80 +287,31 @@ func callTool(ctx context.Context, client *http.Client, serverURL string, params
 	return parsed, nil
 }
 
-func callToolRaw(ctx context.Context, client *http.Client, serverURL string, params ToolCallParams) (map[string]any, error) {
+func (m *MCPServer) callToolRaw(ctx context.Context, params ToolCallParams) (map[string]any, error) {
 	reqBody := JSONRPCRequest{
 		JSONRPC: "2.0",
 		Method:  "tools/call",
 		Params:  mustMarshal(params),
-		ID:      1,
+		ID:      3,
 	}
-	return callJSONRPC(ctx, client, serverURL, reqBody)
+	return m.call(ctx, reqBody)
 }
 
-type InitializeParams struct {
-	ProtocolVersion string `json:"protocolVersion"`
-	Capabilities   map[string]any `json:"capabilities"`
-	ClientInfo     ClientInfo `json:"clientInfo"`
-}
-
-type ClientInfo struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-}
-
-func initializeServer(ctx context.Context, client *http.Client, serverURL string) error {
-	params := InitializeParams{
-		ProtocolVersion: "2024-11-05",
-		Capabilities:  map[string]any{},
-		ClientInfo: ClientInfo{
-			Name:    "test-mcp",
-			Version: "1.0.0",
-		},
-	}
-
-	reqBody := JSONRPCRequest{
-		JSONRPC: "2.0",
-		Method:  "initialize",
-		Params:  mustMarshal(params),
-		ID:      1,
-	}
-
-	result, err := callJSONRPC(ctx, client, serverURL, reqBody)
-	if err != nil {
-		return fmt.Errorf("initialize failed: %w", err)
-	}
-
-	fmt.Fprintf(os.Stderr, "Initialized: %v\n", result)
-
-	notifReq := JSONRPCRequest{
-		JSONRPC: "2.0",
-		Method:  "notifications/initialized",
-	}
-
-	_, _ = callJSONRPC(ctx, client, serverURL, notifReq)
-
-	return nil
-}
-
-func callJSONRPC(ctx context.Context, client *http.Client, serverURL string, reqBody JSONRPCRequest) (map[string]any, error) {
-	body, err := json.Marshal(reqBody)
+func (m *MCPServer) call(ctx context.Context, req JSONRPCRequest) (map[string]any, error) {
+	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", serverURL, io.NopCloser(
-		io.NopCloser(
-			&readCloseProxy{data: body},
-		),
-	))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", m.serverURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json, text/event-stream")
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json, text/event-stream")
 
-	resp, err := client.Do(req)
+	resp, err := m.client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
@@ -337,8 +342,8 @@ func callJSONRPC(ctx context.Context, client *http.Client, serverURL string, req
 	}
 
 	result, ok := rpcResp.Result.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("unexpected result type")
+	if !ok && rpcResp.Result != nil {
+		return nil, fmt.Errorf("unexpected result type: %T", rpcResp.Result)
 	}
 
 	return result, nil


### PR DESCRIPTION
The goal of these tests is to make sure that the system is working as
intended. If you want to run these tests I suggest you to have a
bare-metal Debian 12 or Debian 13 system with a large number of
libvirt-related packages installed, as the scripts will try to use these
tools. You shall also have a good Internet connection (the scripts will
download and install many distribution .iso and set up virtual images
for more than 20 different configurations).

The set up phase for these test takes a few hours and requires more than
300GB or free disk space.

If all these numbers are not frightening you, please feel free to use
then. For this, simply go to the ./tests/integration directory and run

	./run.sh <distrib> <version> <desktop-env> <session-type>

Where
* distrib is debian, ubuntu or fedora
* version depends on the distrib (12 or 13 for debian...)
* desktop-env is either gnome or kde
* session-type is either x11 or wayland

Not all tests are working. The results might depend on the current state
of the perfuncted library. At the time of writing, it uses the Shell Eval extension for Gnome to get window information, and this might fail, as some OSes are restricting the use of this extenstion to debug mode.

Don't say you have not wbeen warned :)
