### PR TITLE
capture: add window state fields to Window struct

### DIFF
--- a/gnome-extension/screenshooter-mcp@deloget.com_legacy/extension.js
+++ b/gnome-extension/screenshooter-mcp@deloget.com_legacy/extension.js
@@ -46,21 +46,24 @@ var WindowsDBus = class WindowsDBus {
     }
 
     List() {
+        const focusWindow = global.display.get_focus_window();
         const windows = global.get_window_actors()
             .filter(a => !a.get_meta_window().is_skip_taskbar())
             .map(a => {
                 const w = a.get_meta_window();
                 const r = w.get_frame_rect();
                 return {
-                    id:        new GLib.Variant('t', w.get_stable_sequence()),
-                    title:     new GLib.Variant('s', w.get_title() || ''),
-                    pid:       new GLib.Variant('i', w.get_pid()),
-                    x:         new GLib.Variant('i', r.x),
-                    y:         new GLib.Variant('i', r.y),
-                    w:         new GLib.Variant('i', r.width),
-                    h:         new GLib.Variant('i', r.height),
-                    minimized: new GLib.Variant('b', w.minimized),
-                    maximized: new GLib.Variant('b', w.maximized),
+                    id:         new GLib.Variant('t', w.get_stable_sequence()),
+                    title:      new GLib.Variant('s', w.get_title() || ''),
+                    pid:        new GLib.Variant('i', w.get_pid()),
+                    x:          new GLib.Variant('i', r.x),
+                    y:          new GLib.Variant('i', r.y),
+                    w:          new GLib.Variant('i', r.width),
+                    h:          new GLib.Variant('i', r.height),
+                    minimized:  new GLib.Variant('b', w.minimized),
+                    maximized:  new GLib.Variant('b', w.maximized),
+                    activated:  new GLib.Variant('b', w === focusWindow),
+                    fullscreen: new GLib.Variant('b', w.fullscreen),
                 };
             });
         return new GLib.Variant('(aa{sv})', [windows]);

--- a/gnome-extension/screenshooter-mcp@deloget.com_modern/extension.js
+++ b/gnome-extension/screenshooter-mcp@deloget.com_modern/extension.js
@@ -45,21 +45,24 @@ class WindowsDBus {
     }
 
     List() {
+        const focusWindow = global.display.get_focus_window();
         const windows = global.get_window_actors()
             .filter(a => !a.get_meta_window().is_skip_taskbar())
             .map(a => {
                 const w = a.get_meta_window();
                 const r = w.get_frame_rect();
                 return {
-                    id:        new GLib.Variant('t', w.get_stable_sequence()),
-                    title:     new GLib.Variant('s', w.get_title() || ''),
-                    pid:       new GLib.Variant('i', w.get_pid()),
-                    x:         new GLib.Variant('i', r.x),
-                    y:         new GLib.Variant('i', r.y),
-                    w:         new GLib.Variant('i', r.width),
-                    h:         new GLib.Variant('i', r.height),
-                    minimized: new GLib.Variant('b', w.minimized),
-                    maximized: new GLib.Variant('b', w.maximized),
+                    id:         new GLib.Variant('t', w.get_stable_sequence()),
+                    title:      new GLib.Variant('s', w.get_title() || ''),
+                    pid:        new GLib.Variant('i', w.get_pid()),
+                    x:          new GLib.Variant('i', r.x),
+                    y:          new GLib.Variant('i', r.y),
+                    w:          new GLib.Variant('i', r.width),
+                    h:          new GLib.Variant('i', r.height),
+                    minimized:  new GLib.Variant('b', w.minimized),
+                    maximized:  new GLib.Variant('b', w.maximized),
+                    activated:  new GLib.Variant('b', w === focusWindow),
+                    fullscreen: new GLib.Variant('b', w.fullscreen),
                 };
             });
         return new GLib.Variant('(aa{sv})', [windows]);

--- a/internal/capture/types.go
+++ b/internal/capture/types.go
@@ -87,6 +87,18 @@ type Window struct {
 
 	// Height is the window's height in pixels.
 	Height int
+
+	// Active indicates whether this window currently has focus.
+	Active bool
+
+	// Minimized indicates whether this window is minimized.
+	Minimized bool
+
+	// Maximized indicates whether this window is maximized.
+	Maximized bool
+
+	// Fullscreen indicates whether this window is in fullscreen mode.
+	Fullscreen bool
 }
 
 // WindowID is the type used to identify windows.

--- a/internal/capture/wayland/capture.go
+++ b/internal/capture/wayland/capture.go
@@ -213,14 +213,18 @@ func (c *WaylandCapture) ListWindows() ([]capture.Window, error) {
 	windows := make([]capture.Window, 0, len(windowList))
 	for _, w := range windowList {
 		windows = append(windows, capture.Window{
-			ID:     capture.WindowID(w.ID),
-			Name:   w.Title,
-			X:      w.X,
-			Y:      w.Y,
-			Width:  w.W,
-			Height: w.H,
+			ID:         capture.WindowID(w.ID),
+			Name:       w.Title,
+			X:          w.X,
+			Y:          w.Y,
+			Width:      w.W,
+			Height:     w.H,
+			Active:     w.Active,
+			Minimized:  w.Minimized,
+			Maximized:  w.Maximized,
+			Fullscreen: w.Fullscreen,
 		})
-		logging.Debug().Uint64("id", w.ID).Str("title", w.Title).Int("x", w.X).Int("y", w.Y).Int("width", w.W).Int("height", w.H).Msg("Found window")
+		logging.Debug().Uint64("id", w.ID).Str("title", w.Title).Int("x", w.X).Int("y", w.Y).Int("width", w.W).Int("height", w.H).Bool("active", w.Active).Msg("Found window")
 	}
 
 	return windows, nil

--- a/internal/capture/wayland/gnome.go
+++ b/internal/capture/wayland/gnome.go
@@ -55,15 +55,17 @@ func (g *GnomeManager) IterateWindows(ctx context.Context) iter.Seq2[window.Info
 		}
 		for _, e := range raw {
 			w := window.Info{
-				ID:        e["id"].Value().(uint64),
-				Title:     e["title"].Value().(string),
-				PID:       e["pid"].Value().(int32),
-				X:         int(e["x"].Value().(int32)),
-				Y:         int(e["y"].Value().(int32)),
-				W:         int(e["w"].Value().(int32)),
-				H:         int(e["h"].Value().(int32)),
-				Minimized: e["minimized"].Value().(bool),
-				Maximized: e["maximized"].Value().(bool),
+				ID:         e["id"].Value().(uint64),
+				Title:      e["title"].Value().(string),
+				PID:        e["pid"].Value().(int32),
+				X:          int(e["x"].Value().(int32)),
+				Y:          int(e["y"].Value().(int32)),
+				W:          int(e["w"].Value().(int32)),
+				H:          int(e["h"].Value().(int32)),
+				Minimized:  e["minimized"].Value().(bool),
+				Maximized:  e["maximized"].Value().(bool),
+				Active:     e["activated"].Value().(bool),
+				Fullscreen: e["fullscreen"].Value().(bool),
 			}
 			if !yield(w, nil) {
 				return

--- a/internal/capture/x11/capture.go
+++ b/internal/capture/x11/capture.go
@@ -174,14 +174,18 @@ func (c *X11Capture) ListWindows() ([]capture.Window, error) {
 	windows := make([]capture.Window, 0, len(windowList))
 	for _, w := range windowList {
 		windows = append(windows, capture.Window{
-			ID:     capture.WindowID(w.ID),
-			Name:   w.Title,
-			X:      w.X,
-			Y:      w.Y,
-			Width:  w.W,
-			Height: w.H,
+			ID:         capture.WindowID(w.ID),
+			Name:       w.Title,
+			X:          w.X,
+			Y:          w.Y,
+			Width:      w.W,
+			Height:     w.H,
+			Active:     w.Active,
+			Minimized:  w.Minimized,
+			Maximized:  w.Maximized,
+			Fullscreen: w.Fullscreen,
 		})
-		logging.Debug().Uint64("id", w.ID).Str("title", w.Title).Int("x", w.X).Int("y", w.Y).Int("width", w.W).Int("height", w.H).Msg("Found window")
+		logging.Debug().Uint64("id", w.ID).Str("title", w.Title).Int("x", w.X).Int("y", w.Y).Int("width", w.W).Int("height", w.H).Bool("active", w.Active).Msg("Found window")
 	}
 
 	return windows, nil


### PR DESCRIPTION
Add Active, Minimized, Maximized, and Fullscreen fields to the Window struct returned by list_windows. These fields are populated from the perfuncted window.Info struct on both X11 and Wayland backends.

The GNOME Shell extension was also updated to expose activated and fullscreen properties via D-Bus, matching the perfuncted API.

This gives agents visibility into window state without requiring any write operations or input injection.
