### PR TITLE
vision: add compare_images tool for two-image comparison

### DIFF
--- a/cmd/screenshooter-mcp-server/main.go
+++ b/cmd/screenshooter-mcp-server/main.go
@@ -409,6 +409,15 @@ type findRegionInput struct {
 	Provider    string `json:"provider,omitempty" jsonschema:"optional provider name; uses default if not specified"`
 }
 
+// compareImagesInput defines the input parameters for the compare_images MCP tool.
+type compareImagesInput struct {
+	ImageBase64  string `json:"image_base64" jsonschema:"base64-encoded PNG image data (first image)"`
+	Image2Base64 string `json:"image2_base64" jsonschema:"base64-encoded PNG image data (second image)"`
+	Prompt       string `json:"prompt,omitempty" jsonschema:"optional comparison prompt; uses default if not specified"`
+	Provider     string `json:"provider,omitempty" jsonschema:"optional provider name; uses default if not specified"`
+	Timeout      int    `json:"timeout,omitempty" jsonschema:"optional timeout in seconds; 0 uses provider default"`
+}
+
 // RegionResult represents the bounding box coordinates returned by find_region.
 type RegionResult struct {
 	X      int `json:"x"`
@@ -828,6 +837,54 @@ func registerTools(server *mcp.Server, t *tools.Tools) {
 		}, nil, nil
 	})
 	toolNames = append(toolNames, "find_region")
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "compare_images",
+		Description: "Compare two images and describe the differences",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args *compareImagesInput) (*mcp.CallToolResult, any, error) {
+		logging.Debug().Str("tool", "compare_images").Str("provider", args.Provider).Msg("Tool called")
+		image1Data, err := base64.StdEncoding.DecodeString(args.ImageBase64)
+		if err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: fmt.Sprintf("Failed to decode first image: %v", err)},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+		image2Data, err := base64.StdEncoding.DecodeString(args.Image2Base64)
+		if err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: fmt.Sprintf("Failed to decode second image: %v", err)},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+
+		prompt := args.Prompt
+		if prompt == "" {
+			prompt = "Describe the differences between these two images. Be specific about what changed."
+		}
+
+		result, err := t.CompareImages(ctx, image1Data, image2Data, prompt, args.Provider, args.Timeout)
+		if err != nil {
+			logging.Error().Err(err).Str("tool", "compare_images").Msg("Tool failed")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: fmt.Sprintf("Failed to compare images: %v", err)},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: result},
+			},
+		}, nil, nil
+	})
+	toolNames = append(toolNames, "compare_images")
 
 	logging.Info().Strs("tools", toolNames).Msg("Tools registered")
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"image"
 	"image/png"
+	"time"
 
 	"github.com/emmanuel-deloget/screenshooter-mcp/internal/capture"
 	"github.com/emmanuel-deloget/screenshooter-mcp/internal/vision"
@@ -219,6 +220,26 @@ Coordinates are in pixels relative to the top-left corner of the image.
 Do not include any explanation or markdown formatting.`, description)
 
 	return t.vision.AnalyzeWith(ctx, provider, image, prompt)
+}
+
+// CompareImages sends two images to a vision provider for comparison.
+//
+// Both image arguments should be PNG-encoded bytes. The prompt argument
+// specifies what comparison to perform. If provider is empty, the default
+// provider is used. If timeout is non-zero, it overrides the provider's
+// configured timeout for this call (in seconds).
+//
+// Returns the text response from the AI model describing the comparison.
+func (t *Tools) CompareImages(ctx context.Context, image1 []byte, image2 []byte, prompt string, provider string, timeout int) (string, error) {
+	if t.vision == nil {
+		return "", fmt.Errorf("no vision providers configured")
+	}
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
+	return t.vision.CompareImages(ctx, provider, image1, image2, prompt)
 }
 
 // encodeImage converts an image.Image to PNG-encoded bytes.

--- a/internal/vision/anthropic.go
+++ b/internal/vision/anthropic.go
@@ -114,3 +114,79 @@ func (p *anthropicProvider) Analyze(ctx context.Context, image []byte, prompt st
 	logging.Debug().Str("provider", p.name).Str("model", p.model).Int("response_size", len(result)).Msg("Anthropic API response received")
 	return result, nil
 }
+
+func (p *anthropicProvider) CompareImages(ctx context.Context, image1 []byte, image2 []byte, prompt string) (string, error) {
+	opts := []option.RequestOption{
+		option.WithAPIKey(p.apiKey),
+	}
+	if p.baseURL != "" {
+		opts = append(opts, option.WithBaseURL(p.baseURL))
+	}
+
+	client := anthropic.NewClient(opts...)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(p.timeout)*time.Second)
+	defer cancel()
+
+	base64Image1 := base64.StdEncoding.EncodeToString(image1)
+	base64Image2 := base64.StdEncoding.EncodeToString(image2)
+	logging.Debug().Str("provider", p.name).Str("model", p.model).Int("image1_size", len(image1)).Int("image2_size", len(image2)).Msg("Sending comparison request to Anthropic API")
+
+	msg, err := client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     p.model,
+		MaxTokens: 4096,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(
+				anthropic.ContentBlockParamUnion{
+					OfText: &anthropic.TextBlockParam{
+						Text: prompt,
+					},
+				},
+				anthropic.ContentBlockParamUnion{
+					OfImage: &anthropic.ImageBlockParam{
+						Source: anthropic.ImageBlockParamSourceUnion{
+							OfBase64: &anthropic.Base64ImageSourceParam{
+								Data:      base64Image1,
+								MediaType: anthropic.Base64ImageSourceMediaTypeImagePNG,
+							},
+						},
+					},
+				},
+				anthropic.ContentBlockParamUnion{
+					OfImage: &anthropic.ImageBlockParam{
+						Source: anthropic.ImageBlockParamSourceUnion{
+							OfBase64: &anthropic.Base64ImageSourceParam{
+								Data:      base64Image2,
+								MediaType: anthropic.Base64ImageSourceMediaTypeImagePNG,
+							},
+						},
+					},
+				},
+			),
+		},
+	})
+	if err != nil {
+		logging.Error().Str("provider", p.name).Str("model", p.model).Err(err).Msg("Anthropic API comparison request failed")
+		return "", fmt.Errorf("message completion failed: %w", err)
+	}
+
+	if len(msg.Content) == 0 {
+		logging.Warn().Str("provider", p.name).Str("model", p.model).Msg("No content in response")
+		return "", fmt.Errorf("no response from provider %s", p.name)
+	}
+
+	var result string
+	for _, block := range msg.Content {
+		if block.Type == "text" {
+			result += block.Text
+		}
+	}
+
+	if result == "" {
+		logging.Warn().Str("provider", p.name).Str("model", p.model).Msg("No text content in response")
+		return "", fmt.Errorf("no text content in response from provider %s", p.name)
+	}
+
+	logging.Debug().Str("provider", p.name).Str("model", p.model).Int("response_size", len(result)).Msg("Anthropic API comparison response received")
+	return result, nil
+}

--- a/internal/vision/openai.go
+++ b/internal/vision/openai.go
@@ -92,3 +92,59 @@ func (p *openAICompatibleProvider) Analyze(ctx context.Context, image []byte, pr
 	logging.Debug().Str("provider", p.name).Str("model", p.model).Int("response_tokens", resp.Usage.CompletionTokens).Msg("OpenAI-compatible API response received")
 	return resp.Choices[0].Message.Content, nil
 }
+
+func (p *openAICompatibleProvider) CompareImages(ctx context.Context, image1 []byte, image2 []byte, prompt string) (string, error) {
+	cfg := openai.DefaultConfig(p.apiKey)
+	if p.baseURL != "" {
+		cfg.BaseURL = p.baseURL
+	}
+	client := openai.NewClientWithConfig(cfg)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(p.timeout)*time.Second)
+	defer cancel()
+
+	base64Image1 := base64.StdEncoding.EncodeToString(image1)
+	base64Image2 := base64.StdEncoding.EncodeToString(image2)
+	logging.Debug().Str("provider", p.name).Str("model", p.model).Int("image1_size", len(image1)).Int("image2_size", len(image2)).Msg("Sending comparison request to OpenAI-compatible API")
+
+	resp, err := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: p.model,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role: openai.ChatMessageRoleUser,
+				MultiContent: []openai.ChatMessagePart{
+					{
+						Type: openai.ChatMessagePartTypeText,
+						Text: prompt,
+					},
+					{
+						Type: openai.ChatMessagePartTypeImageURL,
+						ImageURL: &openai.ChatMessageImageURL{
+							URL:    "data:image/png;base64," + base64Image1,
+							Detail: openai.ImageURLDetailAuto,
+						},
+					},
+					{
+						Type: openai.ChatMessagePartTypeImageURL,
+						ImageURL: &openai.ChatMessageImageURL{
+							URL:    "data:image/png;base64," + base64Image2,
+							Detail: openai.ImageURLDetailAuto,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		logging.Error().Str("provider", p.name).Str("model", p.model).Err(err).Msg("OpenAI-compatible API comparison request failed")
+		return "", fmt.Errorf("chat completion failed: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		logging.Warn().Str("provider", p.name).Str("model", p.model).Msg("No choices in response")
+		return "", fmt.Errorf("no response from provider %s", p.name)
+	}
+
+	logging.Debug().Str("provider", p.name).Str("model", p.model).Int("response_tokens", resp.Usage.CompletionTokens).Msg("OpenAI-compatible API comparison response received")
+	return resp.Choices[0].Message.Content, nil
+}

--- a/internal/vision/vision.go
+++ b/internal/vision/vision.go
@@ -45,6 +45,18 @@ type Provider interface {
 	Analyze(ctx context.Context, image []byte, prompt string) (string, error)
 }
 
+// ImageComparer extends Provider with the ability to compare two images.
+//
+// Not all providers support multi-image input. Providers that implement
+// this interface can compare two images side by side.
+type ImageComparer interface {
+	Provider
+
+	// CompareImages sends two images and a prompt to the AI model and
+	// returns a text response describing the comparison.
+	CompareImages(ctx context.Context, image1 []byte, image2 []byte, prompt string) (string, error)
+}
+
 // ProviderInfo contains metadata about a configured provider.
 type ProviderInfo struct {
 	// Name is the unique identifier for this provider.
@@ -185,6 +197,38 @@ func (m *Manager) AnalyzeWith(ctx context.Context, name string, image []byte, pr
 	}
 
 	logging.Debug().Str("provider", p.Name()).Int("response_size", len(result)).Msg("Provider analysis complete")
+	return result, nil
+}
+
+// CompareImages uses a specific provider to compare two images.
+//
+// If name is empty, uses the default provider.
+// Returns an error if the provider does not support image comparison
+// or if the provider is not found.
+func (m *Manager) CompareImages(ctx context.Context, name string, image1 []byte, image2 []byte, prompt string) (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("no vision providers configured")
+	}
+
+	p := m.Get(name)
+	if p == nil {
+		logging.Error().Str("provider", name).Msg("Provider not found")
+		return "", fmt.Errorf("provider %q not found", name)
+	}
+
+	cp, ok := p.(ImageComparer)
+	if !ok {
+		return "", fmt.Errorf("provider %q does not support image comparison", p.Name())
+	}
+
+	logging.Debug().Str("provider", p.Name()).Int("image1_size", len(image1)).Int("image2_size", len(image2)).Str("prompt_preview", truncatePrompt(prompt)).Msg("Sending images to provider for comparison")
+	result, err := cp.CompareImages(ctx, image1, image2, prompt)
+	if err != nil {
+		logging.Error().Str("provider", p.Name()).Err(err).Msg("Provider image comparison failed")
+		return "", err
+	}
+
+	logging.Debug().Str("provider", p.Name()).Int("response_size", len(result)).Msg("Provider image comparison complete")
 	return result, nil
 }
 


### PR DESCRIPTION
Add a new compare_images vision tool that sends two images to an AI provider and returns a text description of the differences. Implemented for OpenAI-compatible and Anthropic providers. HuggingFace is excluded as two-image support is model-dependent.

The tool uses an ImageComparer interface to separate providers that support multi-image input from those that don't. A default prompt is provided when the user doesn't specify one.

Also adds an optional timeout parameter to the tool, consistent with other vision tools.
