### PR TITLE
tools: add timeout parameter to vision tool methods

### DIFF
--- a/cmd/screenshooter-mcp-server/main.go
+++ b/cmd/screenshooter-mcp-server/main.go
@@ -394,12 +394,14 @@ type analyzeImageInput struct {
 	ImageBase64 string `json:"image_base64" jsonschema:"base64-encoded PNG image data"`
 	Prompt      string `json:"prompt" jsonschema:"text prompt describing what analysis to perform"`
 	Provider    string `json:"provider,omitempty" jsonschema:"optional provider name; uses default if not specified"`
+	Timeout     int    `json:"timeout,omitempty" jsonschema:"optional timeout in seconds; 0 uses provider default"`
 }
 
 // extractTextInput defines the input parameters for the extract_text MCP tool.
 type extractTextInput struct {
 	ImageBase64 string `json:"image_base64" jsonschema:"base64-encoded PNG image data"`
 	Provider    string `json:"provider,omitempty" jsonschema:"optional provider name; uses default if not specified"`
+	Timeout     int    `json:"timeout,omitempty" jsonschema:"optional timeout in seconds; 0 uses provider default"`
 }
 
 // findRegionInput defines the input parameters for the find_region MCP tool.
@@ -407,6 +409,7 @@ type findRegionInput struct {
 	ImageBase64 string `json:"image_base64" jsonschema:"base64-encoded PNG image data"`
 	Description string `json:"description" jsonschema:"description of the element to find"`
 	Provider    string `json:"provider,omitempty" jsonschema:"optional provider name; uses default if not specified"`
+	Timeout     int    `json:"timeout,omitempty" jsonschema:"optional timeout in seconds; 0 uses provider default"`
 }
 
 // RegionResult represents the bounding box coordinates returned by find_region.
@@ -731,7 +734,7 @@ func registerTools(server *mcp.Server, t *tools.Tools) {
 			}, nil, nil
 		}
 
-		result, err := t.AnalyzeImage(ctx, imageData, args.Prompt, args.Provider)
+		result, err := t.AnalyzeImage(ctx, imageData, args.Prompt, args.Provider, args.Timeout)
 		if err != nil {
 			logging.Error().Err(err).Str("tool", "analyze_image").Msg("Tool failed")
 			return &mcp.CallToolResult{
@@ -765,7 +768,7 @@ func registerTools(server *mcp.Server, t *tools.Tools) {
 			}, nil, nil
 		}
 
-		result, err := t.ExtractText(ctx, imageData, args.Provider)
+		result, err := t.ExtractText(ctx, imageData, args.Provider, args.Timeout)
 		if err != nil {
 			logging.Error().Err(err).Str("tool", "extract_text").Msg("Tool failed")
 			return &mcp.CallToolResult{
@@ -799,7 +802,7 @@ func registerTools(server *mcp.Server, t *tools.Tools) {
 			}, nil, nil
 		}
 
-		result, err := t.FindRegion(ctx, imageData, args.Description, args.Provider)
+		result, err := t.FindRegion(ctx, imageData, args.Description, args.Provider, args.Timeout)
 		if err != nil {
 			logging.Error().Err(err).Str("tool", "find_region").Msg("Tool failed")
 			return &mcp.CallToolResult{

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"image"
 	"image/png"
+	"time"
 
 	"github.com/emmanuel-deloget/screenshooter-mcp/internal/capture"
 	"github.com/emmanuel-deloget/screenshooter-mcp/internal/vision"
@@ -164,12 +165,18 @@ func (t *Tools) ListVisionProviders(ctx context.Context) ([]vision.ProviderInfo,
 //
 // The image argument should be PNG-encoded bytes. The prompt argument
 // specifies what analysis to perform. If provider is empty, the default
-// provider is used.
+// provider is used. If timeout is non-zero, it overrides the provider's
+// configured timeout for this call (in seconds).
 //
 // Returns the text response from the AI model.
-func (t *Tools) AnalyzeImage(ctx context.Context, image []byte, prompt string, provider string) (string, error) {
+func (t *Tools) AnalyzeImage(ctx context.Context, image []byte, prompt string, provider string, timeout int) (string, error) {
 	if t.vision == nil {
 		return "", fmt.Errorf("no vision providers configured")
+	}
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
 	}
 	return t.vision.AnalyzeWith(ctx, provider, image, prompt)
 }
@@ -177,13 +184,19 @@ func (t *Tools) AnalyzeImage(ctx context.Context, image []byte, prompt string, p
 // ExtractText performs OCR on an image and returns structured markdown text.
 //
 // The image argument should be PNG-encoded bytes. If provider is empty,
-// the default provider is used.
+// the default provider is used. If timeout is non-zero, it overrides the
+// provider's configured timeout for this call (in seconds).
 //
 // The prompt instructs the model to extract text and format it as markdown
 // preserving structure (headings, bold, lists, tables, code blocks).
-func (t *Tools) ExtractText(ctx context.Context, image []byte, provider string) (string, error) {
+func (t *Tools) ExtractText(ctx context.Context, image []byte, provider string, timeout int) (string, error) {
 	if t.vision == nil {
 		return "", fmt.Errorf("no vision providers configured")
+	}
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
 	}
 
 	const extractTextPrompt = `Extract all text from this image.
@@ -202,12 +215,18 @@ Maintain the original language.`
 //
 // The image argument should be PNG-encoded bytes. The description argument
 // specifies what element to find (e.g., "the search button", "the logo").
-// If provider is empty, the default provider is used.
+// If provider is empty, the default provider is used. If timeout is non-zero,
+// it overrides the provider's configured timeout for this call (in seconds).
 //
 // Returns the coordinates as x, y, width, height in pixels.
-func (t *Tools) FindRegion(ctx context.Context, image []byte, description string, provider string) (string, error) {
+func (t *Tools) FindRegion(ctx context.Context, image []byte, description string, provider string, timeout int) (string, error) {
 	if t.vision == nil {
 		return "", fmt.Errorf("no vision providers configured")
+	}
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
 	}
 
 	prompt := fmt.Sprintf(`Find the bounding box coordinates of: %s


### PR DESCRIPTION
Add an optional timeout field to analyze_image, extract_text, and find_region input structs. When non-zero, the timeout overrides the provider's configured default for that specific call. When zero, the provider's default timeout is used.

This allows agents to use longer timeouts for complex analysis tasks or shorter timeouts for quick checks without reconfiguring the server.
