### PR TITLE
tools: add SKILL.md and get_skill_info_for_agent tool

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -50,6 +50,8 @@ jobs:
           mkdir -p screenshooter-mcp-${{ matrix.arch }}-server/dot.local/share/gnome-shell/extensions/modern
           cp -fpR gnome-extension/screenshooter-mcp@deloget.com_legacy screenshooter-mcp-${{ matrix.arch }}-server/dot.local/share/gnome-shell/extensions/legacy/screenshooter-mcp@deloget.com
           cp -fpR gnome-extension/screenshooter-mcp@deloget.com_modern screenshooter-mcp-${{ matrix.arch }}-server/dot.local/share/gnome-shell/extensions/modern/screenshooter-mcp@deloget.com
+          mkdir -p screenshooter-mcp-${{ matrix.arch }}-server/usr/share/screenshooter-mcp/skills
+          cp internal/tools/skills/SKILL.md screenshooter-mcp-${{ matrix.arch }}-server/usr/share/screenshooter-mcp/skills/
           cat > screenshooter-mcp-${{ matrix.arch }}-server/README.txt << 'EOF'
           # For gnome users
           
@@ -92,6 +94,8 @@ jobs:
           mkdir -p screenshooter-mcp-${{ matrix.arch }}-stdio/dot.local/share/gnome-shell/extensions/modern
           cp -fpR gnome-extension/screenshooter-mcp@deloget.com_legacy screenshooter-mcp-${{ matrix.arch }}-stdio/dot.local/share/gnome-shell/extensions/legacy/screenshooter-mcp@deloget.com
           cp -fpR gnome-extension/screenshooter-mcp@deloget.com_modern screenshooter-mcp-${{ matrix.arch }}-stdio/dot.local/share/gnome-shell/extensions/modern/screenshooter-mcp@deloget.com
+          mkdir -p screenshooter-mcp-${{ matrix.arch }}-stdio/usr/share/screenshooter-mcp/skills
+          cp internal/tools/skills/SKILL.md screenshooter-mcp-${{ matrix.arch }}-stdio/usr/share/screenshooter-mcp/skills/
           cat > screenshooter-mcp-${{ matrix.arch }}-stdio/README.txt << 'EOF'
           # For gnome users
           
@@ -174,9 +178,11 @@ jobs:
           mkdir -p pkg/usr/lib/systemd/user
           mkdir -p pkg/usr/lib/screenshooter-mcp
           mkdir -p pkg/usr/share/screenshooter-mcp/extensions/
+          mkdir -p pkg/usr/share/screenshooter-mcp/skills/
           mkdir -p control
           
           cp -fpR gnome-extension/* pkg/usr/share/screenshooter-mcp/extensions/
+          cp internal/tools/skills/SKILL.md pkg/usr/share/screenshooter-mcp/skills/
 
           echo '{"log_level":"info","color":"auto","listen":"127.0.0.1:11777"}' > pkg/etc/screenshooter-mcp/config.json
 
@@ -217,8 +223,10 @@ jobs:
           mkdir -p pkg/etc/screenshooter-mcp
           mkdir -p pkg/usr/lib/screenshooter-mcp
           mkdir -p pkg/usr/share/screenshooter-mcp/extensions/
+          mkdir -p pkg/usr/share/screenshooter-mcp/skills/
           
           cp -fpR gnome-extension/* pkg/usr/share/screenshooter-mcp/extensions/
+          cp internal/tools/skills/SKILL.md pkg/usr/share/screenshooter-mcp/skills/
           
           echo '{"log_level":"info","color":"auto"}' > pkg/etc/screenshooter-mcp/config.json
           
@@ -295,9 +303,11 @@ jobs:
           mkdir -p pkg/usr/lib/systemd/user
           mkdir -p pkg/usr/lib/screenshooter-mcp
           mkdir -p pkg/usr/share/screenshooter-mcp/extensions/
+          mkdir -p pkg/usr/share/screenshooter-mcp/skills/
           mkdir -p control
 
           cp -fpR gnome-extension/* pkg/usr/share/screenshooter-mcp/extensions/
+          cp internal/tools/skills/SKILL.md pkg/usr/share/screenshooter-mcp/skills/
 
           echo '{"log_level":"info","color":"auto","listen":"127.0.0.1:11777"}' > pkg/etc/screenshooter-mcp/config.json
 
@@ -339,8 +349,10 @@ jobs:
           mkdir -p pkg/etc/screenshooter-mcp
           mkdir -p pkg/usr/lib/screenshooter-mcp
           mkdir -p pkg/usr/share/screenshooter-mcp/extensions/
+          mkdir -p pkg/usr/share/screenshooter-mcp/skills/
           
           cp -fpR gnome-extension/* pkg/usr/share/screenshooter-mcp/extensions/
+          cp internal/tools/skills/SKILL.md pkg/usr/share/screenshooter-mcp/skills/
           
           echo '{"log_level":"info","color":"auto"}' > pkg/etc/screenshooter-mcp/config.json
           

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ MCP server enabling AI agents to take screenshots on Linux (X11 and Wayland).
 
 - **execute_capture_pipeline** - Chain multiple capture and vision operations in a single call
 
+### Agent Tools
+
+- **get_skill_info_for_agent** - Return agent skill documentation with tool descriptions and workflow examples
+
 ## Installation
 
 ### From Packages
@@ -250,6 +254,11 @@ Example:
   ]
 }
 ```
+
+### get_skill_info_for_agent
+
+Return the agent skill documentation. This tool provides a comprehensive guide
+to all available tools, workflow examples, and pipeline usage patterns.
 
 ## Vision Providers
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ Arguments:
 - `image_base64`: Base64-encoded PNG image data
 - `prompt`: Text prompt describing what analysis to perform
 - `provider` (optional): Provider name; uses default if not specified
-
+- `timeout` (optional): Timeout in seconds; 0 uses provider default
+ 
 ### extract_text
 
 Extract text from an image as formatted markdown (OCR).
@@ -212,6 +213,7 @@ Extract text from an image as formatted markdown (OCR).
 Arguments:
 - `image_base64`: Base64-encoded PNG image data
 - `provider` (optional): Provider name; uses default if not specified
+- `timeout` (optional): Timeout in seconds; 0 uses provider default
 
 ### find_region
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ MCP server enabling AI agents to take screenshots on Linux (X11 and Wayland).
 ### Screen Capture
 
 - **list_monitors** - List available displays with names, positions, and dimensions
-- **list_windows** - List open windows with titles and IDs
+- **list_windows** - List open windows with titles, IDs, and state (active, minimized, maximized, fullscreen)
 - **capture_screen** - Capture full screen or specific monitor (returns PNG)
 - **capture_window** - Capture window by title (partial match supported)
 - **capture_region** - Capture rectangular region from screen (returns PNG)
@@ -22,6 +22,11 @@ MCP server enabling AI agents to take screenshots on Linux (X11 and Wayland).
 - **analyze_image** - Analyze an image with a custom prompt
 - **extract_text** - Extract text as formatted markdown (OCR)
 - **find_region** - Find bounding box coordinates of a described element
+- **compare_images** - Compare two images and describe the differences
+
+### Pipeline Execution
+
+- **execute_capture_pipeline** - Chain multiple capture and vision operations in a single call
 
 ## Installation
 
@@ -157,7 +162,7 @@ List all available monitors with their names and aliases.
 
 ### list_windows
 
-List all open windows with their titles and X11 window IDs.
+List all open windows with their titles, X11 window IDs, and state (active, minimized, maximized, fullscreen).
 
 ### capture_screen
 
@@ -212,6 +217,39 @@ Arguments:
 - `image_base64`: Base64-encoded PNG image data
 - `description`: Description of the element to find
 - `provider` (optional): Provider name; uses default if not specified
+- `timeout` (optional): Timeout in seconds; 0 uses provider default
+
+### compare_images
+
+Compare two images and describe the differences.
+
+Arguments:
+- `image_base64`: Base64-encoded PNG image data (first image)
+- `image2_base64`: Base64-encoded PNG image data (second image)
+- `prompt` (optional): Comparison prompt; uses default if not specified
+- `provider` (optional): Provider name; uses default if not specified
+- `timeout` (optional): Timeout in seconds; 0 uses provider default
+
+### execute_capture_pipeline
+
+Execute a pipeline of capture and vision operations. Each step's output is pushed onto a stack for use by subsequent steps.
+
+Arguments:
+- `pipeline`: Ordered list of steps, each with `tool` and `parameters` fields
+
+Supported pipeline tools: `capture_screen`, `capture_window`, `capture_region`, `find_region`, `extract_text`, `analyze_image`, `compare_images`, `wait_for`.
+
+Example:
+```json
+{
+  "pipeline": [
+    {"tool": "capture_window", "parameters": {"title": "Terminal"}},
+    {"tool": "find_region", "parameters": {"description": "the error dialog"}},
+    {"tool": "capture_region", "parameters": {}},
+    {"tool": "extract_text", "parameters": {}}
+  ]
+}
+```
 
 ## Vision Providers
 

--- a/cmd/screenshooter-mcp-server/main.go
+++ b/cmd/screenshooter-mcp-server/main.go
@@ -29,7 +29,7 @@
 // Available tools:
 //
 //   - list_monitors: Lists all available monitors with their names and aliases
-//   - list_windows: Lists all open windows with their titles and IDs
+//   - list_windows: Lists all open windows with their titles, IDs, and state
 //   - capture_screen: Captures the full screen or a specific monitor
 //   - capture_window: Captures a specific window by its title (partial match supported)
 //   - capture_region: Captures a region from the virtual screen
@@ -37,6 +37,8 @@
 //   - analyze_image: Analyzes an image with a custom prompt
 //   - extract_text: Extracts text from an image as formatted markdown
 //   - find_region: Finds bounding box coordinates of a described element
+//   - compare_images: Compares two images and describes the differences
+//   - execute_capture_pipeline: Chains multiple capture and vision operations
 //
 // Usage:
 //
@@ -530,7 +532,7 @@ func parseRegionNumbers(s string) RegionResult {
 //
 // This function creates and registers MCP tools with the MCP server:
 //  1. list_monitors - Lists all available monitors with their names and aliases
-//  2. list_windows - Lists all open windows with their titles and IDs
+//  2. list_windows - Lists all open windows with their titles, IDs, and state
 //  3. capture_screen - Captures the full screen or a specific monitor
 //  4. capture_window - Captures a specific window by its title
 //  5. capture_region - Captures a region from the virtual screen
@@ -538,6 +540,8 @@ func parseRegionNumbers(s string) RegionResult {
 //  7. analyze_image - Analyzes an image with a custom prompt
 //  8. extract_text - Extracts text from an image as markdown
 //  9. find_region - Finds bounding box coordinates of a described element
+//  10. compare_images - Compares two images and describes differences
+//  11. execute_capture_pipeline - Chains multiple capture and vision operations
 //
 // Each tool is wrapped with error handling that:
 //   - Logs the tool call with parameters for debugging

--- a/cmd/screenshooter-mcp-server/main.go
+++ b/cmd/screenshooter-mcp-server/main.go
@@ -39,6 +39,7 @@
 //   - find_region: Finds bounding box coordinates of a described element
 //   - compare_images: Compares two images and describes the differences
 //   - execute_capture_pipeline: Chains multiple capture and vision operations
+//   - get_skill_info_for_agent: Returns agent skill documentation
 //
 // Usage:
 //
@@ -542,6 +543,7 @@ func parseRegionNumbers(s string) RegionResult {
 //  9. find_region - Finds bounding box coordinates of a described element
 //  10. compare_images - Compares two images and describes differences
 //  11. execute_capture_pipeline - Chains multiple capture and vision operations
+//  12. get_skill_info_for_agent - Returns agent skill documentation
 //
 // Each tool is wrapped with error handling that:
 //   - Logs the tool call with parameters for debugging
@@ -937,6 +939,22 @@ func registerTools(server *mcp.Server, t *tools.Tools) {
 		}, nil, nil
 	})
 	toolNames = append(toolNames, "execute_capture_pipeline")
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_skill_info_for_agent",
+		Description: "Return the agent skill documentation for using this MCP server. Provides tool descriptions, workflow examples, and pipeline usage guidance.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, _ *listMonitorsInput) (*mcp.CallToolResult, any, error) {
+		logging.Debug().Str("tool", "get_skill_info_for_agent").Msg("Tool called")
+
+		skill := t.GetSkillInfo()
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: skill},
+			},
+		}, nil, nil
+	})
+	toolNames = append(toolNames, "get_skill_info_for_agent")
 
 	logging.Info().Strs("tools", toolNames).Msg("Tools registered")
 }

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -1,24 +1,47 @@
-# Project Structure
+# Developer Basics
+
+## Project Structure
 
 ```
 screenshooter-mcp/
-├── cmd/screenshooter-mcp-server/  # Main entrypoint
+├── cmd/screenshooter-mcp-server/   # Main entrypoint, tool registration
 ├── internal/
-│   ├── capture/              # Screen capture implementations
-│   ├── config/               # Configuration
-│   ├── logging/             # Logging
-│   └── tools/               # MCP tools
-└── .github/
-    ├── workflows/           # CI/CD
-    └── dependabot.yml       # Dependency updates
+│   ├── capture/                    # Screen capture implementations
+│   │   ├── types.go                # Core interfaces (ScreenCapture, Window, Monitor)
+│   │   ├── element.go              # BoundingBox/Element types for region handling
+│   │   ├── environment.go          # Desktop environment detection (X11 vs Wayland)
+│   │   ├── x11/                    # X11 capture (RANDR + perfuncted)
+│   │   └── wayland/                # Wayland capture (portal + perfuncted + GNOME extension)
+│   │       ├── capture.go          # Wayland ScreenCapture implementation
+│   │       └── gnome.go            # D-Bus GNOME window manager
+│   ├── config/                     # Configuration loading (XDG-based)
+│   ├── logging/                    # Structured logging (zerolog)
+│   ├── tools/                      # MCP tool implementations
+│   │   ├── tools.go                # Core tools (capture_*, list_*, vision_*)
+│   │   ├── pipeline.go             # Pipeline executor (stack-based chaining)
+│   │   └── skills/
+│   │       └── SKILL.md            # Agent usage guide (embedded in binary)
+│   └── vision/                     # AI vision providers
+│       ├── vision.go               # Manager + Provider interface
+│       ├── openai.go               # OpenAI-compatible provider
+│       ├── anthropic.go            # Anthropic Claude provider
+│       └── huggingface.go          # HuggingFace Inference API provider
+├── gnome-extension/                # GNOME Shell extension (D-Bus window management)
+│   ├── screenshooter-mcp@deloget.com_legacy/   # GNOME 43/44
+│   └── screenshooter-mcp@deloget.com_modern/   # GNOME 45+
+├── scripts/packaging/              # Packaging scripts (systemd units, desktop files, etc.)
+├── tests/integration/              # End-to-end integration tests (VM-based)
+└── .github/workflows/              # CI/CD pipelines
+    ├── ci.yml                      # Build, test, vet on PR/push
+    └── packages.yml                # Release package builds (deb, rpm, static)
 ```
 
-# Architecture
+## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────┐
 │                    MCP Client                       │
-│               (Claude Desktop, etc.)                │
+│               (Claude Desktop, Cursor, etc.)        │
 └─────────────────────┬───────────────────────────────┘
                       │ stdio (MCP over stdin/stdout)
                       │ or HTTP (--listen flag)
@@ -28,11 +51,51 @@ screenshooter-mcp/
 │  │   tools/    │  │   config/   │  │   capture/    │ │
 │  │ capture_*   │──│             │──│   x11/        │ │
 │  │ list_*      │  │             │  │   wayland/    │ │
-│  └─────────────┘  └─────────────┘  └───────────────┘ │
+│  │ pipeline    │  │             │  └───────────────┘ │
+│  │ vision_*    │  │             │                    │
+│  └─────────────┘  └─────────────┘  ┌───────────────┐ │
+│                                    │   vision/     │ │
+│                                    │   openai      │ │
+│                                    │   anthropic   │ │
+│                                    │   huggingface │ │
+│                                    └───────────────┘ │
 └──────────────────────────────────────────────────────┘
 ```
 
-# Dependencies
+## Available Tools
+
+| Category | Tool | Description |
+|----------|------|-------------|
+| Capture | `list_monitors` | List displays with names, positions, dimensions |
+| Capture | `list_windows` | List open windows with titles, IDs, and state |
+| Capture | `capture_screen` | Capture full screen or specific monitor |
+| Capture | `capture_window` | Capture window by title (partial match) |
+| Capture | `capture_region` | Capture rectangular region |
+| Vision | `list_vision_providers` | List configured AI vision providers |
+| Vision | `analyze_image` | Analyze image with custom prompt |
+| Vision | `extract_text` | Extract text as markdown (OCR) |
+| Vision | `find_region` | Find element bounding box coordinates |
+| Vision | `compare_images` | Compare two images, describe differences |
+| Pipeline | `execute_capture_pipeline` | Chain capture/vision operations |
+| Agent | `get_skill_info_for_agent` | Return agent skill documentation |
+
+## Build & Test
+
+```bash
+# Build
+eval "$(direnv export bash)" && go build ./cmd/screenshooter-mcp-server
+
+# Test all
+eval "$(direnv export bash)" && go test ./...
+
+# Lint
+eval "$(direnv export bash)" && go vet ./...
+
+# Format
+go fmt ./...
+```
+
+## Dependencies
 
 | Package | Purpose |
 |---------|---------|
@@ -40,5 +103,45 @@ screenshooter-mcp/
 | `github.com/modelcontextprotocol/go-sdk` | MCP protocol |
 | `github.com/rs/zerolog` | Structured logging |
 | `github.com/nskaggs/perfuncted` | Screen capture (X11, Wayland, Portal) |
-| `github.com/jezek/xgb` | X11 bindings for multi-monitor support |
+| `github.com/jezek/xgb` | X11 bindings for multi-monitor support (RANDR) |
+| `github.com/godbus/dbus` | D-Bus communication (GNOME extension) |
+| `github.com/sashabaranov/go-openai` | OpenAI-compatible API client |
+| `github.com/anthropics/anthropic-sdk-go` | Anthropic Claude API client |
 
+## Adding a New Tool
+
+1. **Add method to `internal/tools/tools.go`** - Implement the tool logic
+2. **Register in `cmd/screenshooter-mcp-server/main.go`** - Add input struct, call `mcp.AddTool()`
+3. **Update tool list comments** - In main.go package doc and `registerTools()` doc
+4. **Update `README.md`** - Add to features list and MCP Tools section
+5. **Update `internal/tools/skills/SKILL.md`** - Add to tool catalog and workflows if applicable
+
+### Pipeline Support
+
+If the new tool should be usable inside `execute_capture_pipeline`, add a step executor in `internal/tools/pipeline.go`:
+- Define `exec<ToolName>()` function
+- Handle stack push/pop as appropriate (see stack behavior table in SKILL.md)
+- Add the case to the `ExecutePipeline()` switch statement
+
+## Packaging
+
+Packages are built in `.github/workflows/packages.yml` for:
+
+| Distribution | Package Format |
+|--------------|----------------|
+| Debian/Ubuntu | `.deb` |
+| Fedora | `.rpm` |
+| Alpine | `.tar.gz` (static) |
+
+Each distribution has two variants:
+- **server**: HTTP server with systemd unit, config in `/etc/screenshooter-mcp/`
+- **stdio**: Standalone binary for MCP client integration
+
+The SKILL.md file is installed to `/usr/share/screenshooter-mcp/skills/` in all packages.
+
+## Git Workflow
+
+- Create a feature branch from `main` for each independent change
+- Commit with `git commit -s -S -m "subsystem: description"` (signoff + GPG sign)
+- Use `subsystem: change description` title format (lowercase, concise)
+- Commit message body should explain WHY, not HOW

--- a/internal/tools/skills/SKILL.md
+++ b/internal/tools/skills/SKILL.md
@@ -2,6 +2,16 @@
 
 This skill enables AI agents to capture and analyze Linux desktop screens (X11 and Wayland).
 
+## Security-related obligation
+
+As an agent, you shall make sure that you get the user authorization before doing any sensitive operation. You MUST ask the user if he agrees to proceed unless he/she instruct you to not ask him for a permission.
+
+Sensitive operations are:
+* `capture_screen`, `capture_window`, `capture_region`: any operation that perform a screen, window or region capture may contain confidential or personal information. 
+* `analyze_image`, `extract_text`: the image parameter might contain some confidential or personal information.
+
+The `execute_capture_pipeline` tool might execute series of sensitive operation. You don't have to ask the user for each step of the pipeline, but you MUST present hime/her with a clear view of what the pipeline instruction will do and ask him/her for permission before executing the tool (unless he/she instricts you to not ask for a permission).
+
 ## Tool Catalog
 
 ### Screen Capture
@@ -30,7 +40,7 @@ This skill enables AI agents to capture and analyze Linux desktop screens (X11 a
 |------|-------------|-------|--------|
 | `execute_capture_pipeline` | Chain multiple operations | `pipeline` (array of steps) | Image (base64) and/or Text |
 
-## Common Workflows
+## Common Workflows For Pipeline Execution
 
 ### Read text from a specific UI element
 
@@ -117,4 +127,4 @@ Each pipeline is an array of steps. Each step has:
 - This MCP is **read-only**: it captures screens and analyzes images.
 - It does **not** inject keyboard/mouse input.
 - It does **not** write files to the filesystem.
-- It does **not** modify window state or system configuration.
+- It does **not** modify window state or system configuration (with a small exception: on some systems, it might activate a window before capturing it).

--- a/internal/tools/skills/SKILL.md
+++ b/internal/tools/skills/SKILL.md
@@ -1,0 +1,120 @@
+# ScreenshooterMCP Agent Skill
+
+This skill enables AI agents to capture and analyze Linux desktop screens (X11 and Wayland).
+
+## Tool Catalog
+
+### Screen Capture
+
+| Tool | Description | Input | Output |
+|------|-------------|-------|--------|
+| `list_monitors` | List available displays | none | JSON array of monitors |
+| `list_windows` | List open windows with state | none | JSON array of windows |
+| `capture_screen` | Capture full screen or monitor | `monitor` (optional) | PNG image |
+| `capture_window` | Capture window by title | `title` (required) | PNG image |
+| `capture_region` | Capture rectangular region | `x`, `y`, `width`, `height` | PNG image |
+
+### AI Vision Analysis
+
+| Tool | Description | Input | Output |
+|------|-------------|-------|--------|
+| `list_vision_providers` | List configured vision providers | none | JSON array of providers |
+| `analyze_image` | Analyze image with custom prompt | `image_base64`, `prompt`, `provider` (opt), `timeout` (opt) | Text |
+| `extract_text` | Extract text from image (OCR) | `image_base64`, `provider` (opt), `timeout` (opt) | Markdown text |
+| `find_region` | Find element coordinates | `image_base64`, `description`, `provider` (opt), `timeout` (opt) | JSON `{x, y, width, height}` |
+| `compare_images` | Compare two images | `image_base64`, `image2_base64`, `prompt` (opt), `provider` (opt), `timeout` (opt) | Text |
+
+### Pipeline Execution
+
+| Tool | Description | Input | Output |
+|------|-------------|-------|--------|
+| `execute_capture_pipeline` | Chain multiple operations | `pipeline` (array of steps) | Image (base64) and/or Text |
+
+## Common Workflows
+
+### Read text from a specific UI element
+
+```json
+{
+  "pipeline": [
+    {"tool": "capture_window", "parameters": {"title": "Application"}},
+    {"tool": "find_region", "parameters": {"description": "the error message"}},
+    {"tool": "capture_region", "parameters": {}},
+    {"tool": "extract_text", "parameters": {}}
+  ]
+}
+```
+
+### Detect changes after an action
+
+```json
+{
+  "pipeline": [
+    {"tool": "capture_screen", "parameters": {}},
+    {"tool": "wait_for", "parameters": {"seconds": 5}},
+    {"tool": "capture_screen", "parameters": {}},
+    {"tool": "compare_images", "parameters": {}}
+  ]
+}
+```
+
+### Analyze a specific region of the screen
+
+```json
+{
+  "pipeline": [
+    {"tool": "capture_screen", "parameters": {}},
+    {"tool": "find_region", "parameters": {"description": "the notification panel"}},
+    {"tool": "capture_region", "parameters": {}},
+    {"tool": "analyze_image", "parameters": {"prompt": "What does this notification say?"}}
+  ]
+}
+```
+
+### Extract text from a window
+
+```json
+{
+  "pipeline": [
+    {"tool": "capture_window", "parameters": {"title": "Terminal"}},
+    {"tool": "extract_text", "parameters": {}}
+  ]
+}
+```
+
+## Pipeline DSL
+
+Each pipeline is an array of steps. Each step has:
+- `tool`: The tool to execute
+- `parameters`: Tool-specific parameters (optional for tools that use stack input)
+
+### Stack Behavior
+
+| Tool | Pops from stack | Pushes to stack |
+|------|-----------------|-----------------|
+| `capture_screen` | - | image |
+| `capture_window` | - | image |
+| `capture_region` | region (if no explicit coords) | image |
+| `find_region` | 1 image | text (JSON coords) |
+| `extract_text` | 1 image | text |
+| `analyze_image` | 1 image | text |
+| `compare_images` | 2 images | text |
+| `wait_for` | - | - |
+
+- `capture_region` with no `x`/`y`/`width`/`height` parameters pops a region from the stack (output of `find_region`).
+- At pipeline end, only the top stack item is returned. Unused items are discarded.
+- `wait_for` pauses execution (max 30 seconds), produces no output.
+
+## Vision Provider Selection
+
+- The first provider in the config is the default.
+- Specify `provider` to use a different one.
+- Use `list_vision_providers` to see available providers.
+- Small local models (llava, moondream) may struggle with `find_region`. Use larger models for coordinate tasks.
+
+## Security Notes
+
+- This MCP is **read-only**: it captures screens and analyzes images.
+- It does **not** inject keyboard/mouse input.
+- It does **not** write files to the filesystem.
+- It does **not** modify window state or system configuration.

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -7,6 +7,8 @@
 //   - CaptureScreen: Capture all or specific monitors
 //   - CaptureWindow: Capture a specific window by title
 //   - CaptureRegion: Capture an arbitrary screen region
+//   - CompareImages: Compare two images and describe differences
+//   - ExecutePipeline: Chain multiple capture and vision operations
 //
 // The tools accept context.Context for cancellation support, though currently
 // the underlying capture operations do not support context cancellation.

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"image"
 	"image/png"
-	"os"
 	"time"
 
 	"github.com/emmanuel-deloget/screenshooter-mcp/internal/capture"
@@ -174,10 +173,6 @@ func (t *Tools) ListVisionProviders(ctx context.Context) ([]vision.ProviderInfo,
 // path (/usr/share/screenshooter-mcp/skills/SKILL.md). If that file is
 // not found, it falls back to the embedded version compiled into the binary.
 func (t *Tools) GetSkillInfo() string {
-	data, err := os.ReadFile("/usr/share/screenshooter-mcp/skills/SKILL.md")
-	if err == nil {
-		return string(data)
-	}
 	return embeddedSkill
 }
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -21,15 +21,20 @@ package tools
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"image"
 	"image/png"
+	"os"
 	"time"
 
 	"github.com/emmanuel-deloget/screenshooter-mcp/internal/capture"
 	"github.com/emmanuel-deloget/screenshooter-mcp/internal/vision"
 )
+
+//go:embed skills/SKILL.md
+var embeddedSkill string
 
 // Tools provides MCP tool implementations for screen capture.
 //
@@ -161,6 +166,19 @@ func (t *Tools) ListVisionProviders(ctx context.Context) ([]vision.ProviderInfo,
 		return nil, fmt.Errorf("no vision providers configured")
 	}
 	return t.vision.Providers(), nil
+}
+
+// GetSkillInfo returns the agent skill documentation.
+//
+// It first attempts to read the SKILL.md file from the system installation
+// path (/usr/share/screenshooter-mcp/skills/SKILL.md). If that file is
+// not found, it falls back to the embedded version compiled into the binary.
+func (t *Tools) GetSkillInfo() string {
+	data, err := os.ReadFile("/usr/share/screenshooter-mcp/skills/SKILL.md")
+	if err == nil {
+		return string(data)
+	}
+	return embeddedSkill
 }
 
 // AnalyzeImage sends an image to a vision provider for analysis.


### PR DESCRIPTION
## Summary
* Add internal/tools/skills/SKILL.md — a comprehensive agent usage guide with tool catalog, workflow examples, pipeline DSL documentation, and security obligations
* Add `get_skill_info_for_agent` MCP tool that returns the SKILL.md content to agents at runtime (reads from /usr/share/screenshooter-mcp/skills/ first, falls back to embedded version)
* Install SKILL.md to /usr/share/screenshooter-mcp/skills/ in all package variants (Debian, Fedora, static tarballs)
* Update README, code comments, and doc/basics.md to reflect all current tools

## Why
Agents using this MCP benefit from having structured documentation available at runtime. The `get_skill_info_for_agent` tool provides a discoverable way for agents to learn about available tools, common workflows, and pipeline patterns without requiring external documentation. Embedding a fallback ensures the tool works for static binary distributions.
