### PR TITLE
cmd: handle JSON double-serialization in execute_capture_pipeline

### DIFF
--- a/cmd/screenshooter-mcp-server/main.go
+++ b/cmd/screenshooter-mcp-server/main.go
@@ -426,7 +426,7 @@ type compareImagesInput struct {
 
 // executePipelineInput defines the input parameters for the execute_capture_pipeline MCP tool.
 type executePipelineInput struct {
-	Pipeline []tools.PipelineStep `json:"pipeline" jsonschema:"ordered list of pipeline steps to execute"`
+	Pipeline any `json:"pipeline" jsonschema:"ordered list of pipeline steps to execute"`
 }
 
 // RegionResult represents the bounding box coordinates returned by find_region.
@@ -904,9 +904,19 @@ func registerTools(server *mcp.Server, t *tools.Tools) {
 		Name:        "execute_capture_pipeline",
 		Description: "Execute a pipeline of capture and vision operations. Each step's output is pushed onto a stack for use by subsequent steps. Returns the final result.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args *executePipelineInput) (*mcp.CallToolResult, any, error) {
-		logging.Debug().Int("steps", len(args.Pipeline)).Str("tool", "execute_capture_pipeline").Msg("Tool called")
+		steps, err := DeserializeSlice[tools.PipelineStep](args.Pipeline)
+		if err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: fmt.Sprintf("Invalid pipeline argument: %v", err)},
+				},
+				IsError: true,
+			}, nil, nil
+		}
 
-		imgBase64, text, err := tools.ExecutePipeline(ctx, args.Pipeline, t)
+		logging.Debug().Int("steps", len(steps)).Str("tool", "execute_capture_pipeline").Msg("Tool called")
+
+		imgBase64, text, err := tools.ExecutePipeline(ctx, steps, t)
 		if err != nil {
 			logging.Error().Err(err).Str("tool", "execute_capture_pipeline").Msg("Tool failed")
 			return &mcp.CallToolResult{

--- a/cmd/screenshooter-mcp-server/util.go
+++ b/cmd/screenshooter-mcp-server/util.go
@@ -1,0 +1,46 @@
+// Package main provides utility functions for the screenshooter-mcp-server.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DeserializeSlice handles JSON double-serialization for slice types.
+//
+// Some MCP clients incorrectly serialize array parameters as JSON-encoded strings
+// rather than proper JSON arrays. This function handles both cases:
+//
+//   - If v is already a slice ([]any), it marshals and unmarshals to convert to []T
+//   - If v is a string, it attempts to unmarshal the JSON string into []T
+//   - For any other type, it returns an error
+//
+// This is useful for parameters that contain nested structures like pipelines,
+// where the client might send:
+//
+//	{"pipeline": "[{\"tool\": \"capture_screen\", \"parameters\": {}}]"}  // string (broken)
+//	{"pipeline": [{"tool": "capture_screen", "parameters": {}}]}          // array (correct)
+func DeserializeSlice[T any](v any) ([]T, error) {
+	switch val := v.(type) {
+	case []any:
+		// Client sent a proper array, but we need to convert []any to []T
+		data, err := json.Marshal(val)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize slice: %w", err)
+		}
+		var result []T
+		if err := json.Unmarshal(data, &result); err != nil {
+			return nil, fmt.Errorf("failed to deserialize slice: %w", err)
+		}
+		return result, nil
+	case string:
+		// Client double-encoded the array as a JSON string
+		var result []T
+		if err := json.Unmarshal([]byte(val), &result); err != nil {
+			return nil, fmt.Errorf("failed to deserialize JSON string: %w", err)
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("expected array or JSON-encoded string, got %T", v)
+	}
+}

--- a/cmd/screenshooter-mcp-server/util_test.go
+++ b/cmd/screenshooter-mcp-server/util_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"testing"
+)
+
+type testStep struct {
+	Tool       string         `json:"tool"`
+	Parameters map[string]any `json:"parameters,omitempty"`
+}
+
+func TestDeserializeSlice(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name: "proper array",
+			input: []any{
+				map[string]any{"tool": "capture_screen", "parameters": map[string]any{}},
+				map[string]any{"tool": "capture_window", "parameters": map[string]any{"title": "Files"}},
+			},
+			wantLen: 2,
+			wantErr: false,
+		},
+		{
+			name:    "empty array",
+			input:   []any{},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:    "JSON-encoded string",
+			input:   `[{"tool":"capture_screen","parameters":{}}]`,
+			wantLen: 1,
+			wantErr: false,
+		},
+		{
+			name:    "invalid string",
+			input:   `not json`,
+			wantLen: 0,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type",
+			input:   42,
+			wantLen: 0,
+			wantErr: true,
+		},
+		{
+			name:    "nil input",
+			input:   nil,
+			wantLen: 0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := DeserializeSlice[testStep](tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeserializeSlice() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(result) != tt.wantLen {
+				t.Errorf("DeserializeSlice() got len %d, want %d", len(result), tt.wantLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Some MCP clients incorrectly serialize array parameters as JSON-encoded strings rather than proper JSON arrays. This caused execute_capture_pipeline to fail with a schema validation error.

Add a generic DeserializeSlice[T] function that handles both []any and string inputs, converting them to []T. Update the pipeline handler to use this function for robustness against client serialization differences.

## Type of Change

What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD update

## Testing

Same test as proposed in #34 

## Checklist

- [X] Code follows project style
- [X] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)
- [X] `go vet ./...` passes
- [X] `go test ./...` passes

## Related Issues

Fixes #34 

## Additional context

While this fix should not exists, it seems there are other MCP clients which misbehave in this regard.
* https://github.com/anthropics/claude-code/issues/22394
* https://github.com/QwenLM/qwen-code/issues/379
* https://github.com/makenotion/notion-mcp-server/issues/176

Regarding this last item, a fix has been merged (https://github.com/makenotion/notion-mcp-server/pull/180). This fix is similar in nature.