### PR TITLE
README: fix the name qwen2-vl to qwen3-vl

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The first provider in the list is used by default. Specify `provider` in tool ca
 
 ### Model Limitations
 
-In practice, using small vision models through a local setup (such as llama.cpp or Ollama) may not produce reliable results for all types of vision requests. Notably, the `find_region` tool, which requires the model to identify precise bounding box coordinates, is a particularly difficult task for any vision model — including large models accessed through cloud APIs. Small vision models (such as Qwen2-VL, Moondream, or LLaVA variants) are even more likely to fail or return inaccurate coordinates for this type of request. For best results with `find_region`, consider using a larger, more capable model.
+In practice, using small vision models through a local setup (such as llama.cpp or Ollama) may not produce reliable results for all types of vision requests. Notably, the `find_region` tool, which requires the model to identify precise bounding box coordinates, is a particularly difficult task for any vision model — including large models accessed through cloud APIs. Small vision models (such as Qwen3-VL, Moondream, or LLaVA variants) are even more likely to fail or return inaccurate coordinates for this type of request. For best results with `find_region`, consider using a larger, more capable model.
 
 ## Requirements
 


### PR DESCRIPTION
This is the model I use for testing, and it's very likely that current users are prefering this model over older versions of qwen-vl.
