### PR TITLE
README: update the test result section

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ See `tests/integration/README.md` for requirements and supported configurations.
 | Fedora 43 | KDE / Wayland | ✅  | |
 | Ubuntu 24.04 | GNOME / Wayland | ✅  | ⚠️ Uses `screenshooter-mcp@deloget.com` GNOME extension |
 | Ubuntu 24.04 | GNOME / X11 | ✅  |  |
-| Ubuntu 24.04 | KDE / Wayland | ❌ | `list_windows` times out — KWin 5 (Plasma 5) uses `clientList()` API, upstream `perfuncted` library only supports KWin 6 `windowList()` |
+| Ubuntu 24.04 | KDE / Wayland | ✅  |  |
 | Ubuntu 24.04 | KDE / X11 | ✅  |  |
 | Ubuntu 25.10 | GNOME / Wayland | ✅  | ⚠️ Uses `screenshooter-mcp@deloget.com` GNOME extension |
 | Ubuntu 25.10 | KDE / Wayland | ✅  |  |


### PR DESCRIPTION
The last failing test is now passing thanks to the update of the perfuncted library to v0.2.1. All tests are now passing (the ubuntu 24.04 gnome tests are still slow as hell, needing nearly 200s to have a working SSH connection, but that's not an issue with the screenshooter-mcp installation).
