### PR TITLE
cmd: bump version number to 1.0.0-rc9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ Key features include:
 
 ### Commits
 
-#### v1.0.0 (*unreleased*)
+#### v1.0.0-rc9
 
+- cmd: bump version number to 1.0.0-rc9
 - doc: add more developper oriented documentation (Emmanuel Deloget)
 - cmd: the version is defined as a constant (Emmanuel Deloget)
 - doc: version 0.1.0 never existed, 1.0.0 will (Emmanuel Deloget)

--- a/cmd/screenshooter-mcp-server/main.go
+++ b/cmd/screenshooter-mcp-server/main.go
@@ -115,7 +115,7 @@ type Options struct {
 }
 
 const (
-	ScreenshooterMCPVersion = "v1.0.0-rc8"
+	ScreenshooterMCPVersion = "v1.0.0-rc9"
 )
 
 func main() {


### PR DESCRIPTION
Prepare v1.0.0-rc9

The goal is to check for the new release pipeline.