### PR TITLE
Feature: improve unit testing

### DIFF
--- a/cmd/screenshooter-mcp-server/main_test.go
+++ b/cmd/screenshooter-mcp-server/main_test.go
@@ -130,3 +130,73 @@ func TestParseRegionNumbers(t *testing.T) {
 		})
 	}
 }
+
+func TestRegionResultString(t *testing.T) {
+	tests := []struct {
+		name   string
+		result RegionResult
+		wantX  int
+		wantY  int
+		wantW  int
+		wantH  int
+	}{
+		{
+			name:   "valid result",
+			result: RegionResult{X: 10, Y: 20, Width: 30, Height: 40},
+			wantX:  10,
+			wantY:  20,
+			wantW:  30,
+			wantH:  40,
+		},
+		{
+			name:   "empty result",
+			result: RegionResult{},
+			wantX:  0,
+			wantY:  0,
+			wantW:  0,
+			wantH:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.result.X != tt.wantX {
+				t.Errorf("RegionResult.X = %v, want %v", tt.result.X, tt.wantX)
+			}
+			if tt.result.Y != tt.wantY {
+				t.Errorf("RegionResult.Y = %v, want %v", tt.result.Y, tt.wantY)
+			}
+			if tt.result.Width != tt.wantW {
+				t.Errorf("RegionResult.Width = %v, want %v", tt.result.Width, tt.wantW)
+			}
+			if tt.result.Height != tt.wantH {
+				t.Errorf("RegionResult.Height = %v, want %v", tt.result.Height, tt.wantH)
+			}
+		})
+	}
+}
+
+func TestIndex(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		substr string
+		want   int
+	}{
+		{"found at start", "hello world", "hello", 0},
+		{"found in middle", "hello world", "world", 6},
+		{"found at end", "hello world", "world", 6},
+		{"not found", "hello world", "foo", -1},
+		{"empty string", "", "foo", -1},
+		{"empty substr", "hello", "", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := index(tt.s, tt.substr)
+			if got != tt.want {
+				t.Errorf("index() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/capture/element_test.go
+++ b/internal/capture/element_test.go
@@ -1,55 +1,58 @@
 package capture
 
-import "testing"
+import (
+	"image"
+	"image/color"
+	"testing"
+)
 
 func TestBoundingBoxIsValid(t *testing.T) {
 	tests := []struct {
-		name     string
-		bbox     BoundingBox
-		expected bool
+		name   string
+		bbox   BoundingBox
+		want   bool
 	}{
 		{
-			name:     "valid bounding box",
-			bbox:     BoundingBox{X1: 0, Y1: 0, X2: 100, Y2: 100},
-			expected: true,
+			name: "valid box",
+			bbox: BoundingBox{X1: 10, Y1: 20, X2: 110, Y2: 120},
+			want: true,
 		},
 		{
-			name:     "valid with negative coordinates",
-			bbox:     BoundingBox{X1: -50, Y1: -50, X2: 100, Y2: 100},
-			expected: false,
+			name: "negative X1",
+			bbox: BoundingBox{X1: -1, Y1: 20, X2: 110, Y2: 120},
+			want: false,
 		},
 		{
-			name:     "zero width",
-			bbox:     BoundingBox{X1: 0, Y1: 0, X2: 0, Y2: 100},
-			expected: false,
+			name: "negative Y1",
+			bbox: BoundingBox{X1: 10, Y1: -1, X2: 110, Y2: 120},
+			want: false,
 		},
 		{
-			name:     "zero height",
-			bbox:     BoundingBox{X1: 0, Y1: 0, X2: 100, Y2: 0},
-			expected: false,
+			name: "X2 not greater than X1",
+			bbox: BoundingBox{X1: 10, Y1: 20, X2: 10, Y2: 120},
+			want: false,
 		},
 		{
-			name:     "inverted coordinates",
-			bbox:     BoundingBox{X1: 100, Y1: 100, X2: 0, Y2: 0},
-			expected: false,
+			name: "Y2 not greater than Y1",
+			bbox: BoundingBox{X1: 10, Y1: 20, X2: 110, Y2: 20},
+			want: false,
 		},
 		{
-			name:     "negative x2",
-			bbox:     BoundingBox{X1: 0, Y1: 0, X2: -10, Y2: 100},
-			expected: false,
+			name: "zero width",
+			bbox: BoundingBox{X1: 10, Y1: 20, X2: 10, Y2: 40},
+			want: false,
 		},
 		{
-			name:     "negative y2",
-			bbox:     BoundingBox{X1: 0, Y1: 0, X2: 100, Y2: -10},
-			expected: false,
+			name: "zero height",
+			bbox: BoundingBox{X1: 10, Y1: 20, X2: 110, Y2: 20},
+			want: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.bbox.IsValid()
-			if result != tt.expected {
-				t.Errorf("BoundingBox.IsValid() = %v, want %v", result, tt.expected)
+			if got := tt.bbox.IsValid(); got != tt.want {
+				t.Errorf("BoundingBox.IsValid() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -57,32 +60,26 @@ func TestBoundingBoxIsValid(t *testing.T) {
 
 func TestBoundingBoxWidth(t *testing.T) {
 	tests := []struct {
-		name     string
-		bbox     BoundingBox
-		expected int
+		name   string
+		bbox   BoundingBox
+		want   int
 	}{
 		{
-			name:     "normal width",
-			bbox:     BoundingBox{X1: 10, Y1: 20, X2: 110, Y2: 30},
-			expected: 100,
+			name: "normal box",
+			bbox: BoundingBox{X1: 10, Y1: 20, X2: 110, Y2: 120},
+			want: 100,
 		},
 		{
-			name:     "zero width",
-			bbox:     BoundingBox{X1: 50, Y1: 20, X2: 50, Y2: 30},
-			expected: 0,
-		},
-		{
-			name:     "full width",
-			bbox:     BoundingBox{X1: 0, Y1: 0, X2: 1920, Y2: 1080},
-			expected: 1920,
+			name: "zero width box",
+			bbox: BoundingBox{X1: 10, Y1: 20, X2: 10, Y2: 120},
+			want: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.bbox.Width()
-			if result != tt.expected {
-				t.Errorf("BoundingBox.Width() = %v, want %v", result, tt.expected)
+			if got := tt.bbox.Width(); got != tt.want {
+				t.Errorf("BoundingBox.Width() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -90,33 +87,109 @@ func TestBoundingBoxWidth(t *testing.T) {
 
 func TestBoundingBoxHeight(t *testing.T) {
 	tests := []struct {
-		name     string
-		bbox     BoundingBox
-		expected int
+		name   string
+		bbox   BoundingBox
+		want   int
 	}{
 		{
-			name:     "normal height",
-			bbox:     BoundingBox{X1: 10, Y1: 20, X2: 110, Y2: 120},
-			expected: 100,
+			name: "normal box",
+			bbox: BoundingBox{X1: 10, Y1: 20, X2: 110, Y2: 120},
+			want: 100,
 		},
 		{
-			name:     "zero height",
-			bbox:     BoundingBox{X1: 10, Y1: 50, X2: 110, Y2: 50},
-			expected: 0,
-		},
-		{
-			name:     "full height",
-			bbox:     BoundingBox{X1: 0, Y1: 0, X2: 1920, Y2: 1080},
-			expected: 1080,
+			name: "zero height box",
+			bbox: BoundingBox{X1: 10, Y1: 20, X2: 110, Y2: 20},
+			want: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.bbox.Height()
-			if result != tt.expected {
-				t.Errorf("BoundingBox.Height() = %v, want %v", result, tt.expected)
+			if got := tt.bbox.Height(); got != tt.want {
+				t.Errorf("BoundingBox.Height() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCropToBoundingBox(t *testing.T) {
+	// Create a 100x100 image
+	img := image.NewRGBA(image.Rect(0, 0, 100, 100))
+	for y := 0; y < 100; y++ {
+		for x := 0; x < 100; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 0, A: 255})
+		}
+	}
+
+	tests := []struct {
+		name    string
+		bbox    *BoundingBox
+		wantW   int
+		wantH   int
+		wantErr bool
+	}{
+		{
+			name:  "crop normal region",
+			bbox:  &BoundingBox{X1: 10, Y1: 10, X2: 50, Y2: 50},
+			wantW:  40,
+			wantH:  40,
+		},
+		{
+			name:  "crop region at origin",
+			bbox:  &BoundingBox{X1: 0, Y1: 0, X2: 50, Y2: 50},
+			wantW:  50,
+			wantH:  50,
+		},
+		{
+			name:  "bbox starts before image bounds",
+			bbox:  &BoundingBox{X1: -10, Y1: -10, X2: 50, Y2: 50},
+			wantW:  100,
+			wantH:  100,
+		},
+		{
+			name:  "crop extends beyond image bounds",
+			bbox:  &BoundingBox{X1: 50, Y1: 50, X2: 150, Y2: 150},
+			wantW:  50,
+			wantH:  50,
+		},
+		{
+			name:  "crop completely outside",
+			bbox:  &BoundingBox{X1: 200, Y1: 200, X2: 300, Y2: 300},
+			wantW:  0,
+			wantH:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CropToBoundingBox(img, tt.bbox)
+			bounds := result.Bounds()
+			if bounds.Dx() != tt.wantW {
+				t.Errorf("Cropped width = %v, want %v", bounds.Dx(), tt.wantW)
+			}
+			if bounds.Dy() != tt.wantH {
+				t.Errorf("Cropped height = %v, want %v", bounds.Dy(), tt.wantH)
+			}
+		})
+	}
+}
+
+func TestElement(t *testing.T) {
+	elem := Element{
+		BoundingBox: BoundingBox{
+			X1: 10, Y1: 20, X2: 110, Y2: 120,
+		},
+		Description: "Submit button",
+		Confidence:   0.95,
+	}
+
+	if elem.BoundingBox.X1 != 10 {
+		t.Errorf("Element.BoundingBox.X1 = %v, want 10", elem.BoundingBox.X1)
+	}
+	if elem.Description != "Submit button" {
+		t.Errorf("Element.Description = %v, want 'Submit button'", elem.Description)
+	}
+	if elem.Confidence != 0.95 {
+		t.Errorf("Element.Confidence = %v, want 0.95", elem.Confidence)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,7 +17,7 @@ func TestVisionConfigParsing(t *testing.T) {
 		{
 			name:    "empty config",
 			json:    `{}`,
-			wantErr:  false,
+			wantErr: false,
 			validate: func(t *testing.T, cfg *Config) {
 				if cfg.Vision != nil {
 					t.Error("expected nil Vision for empty config")
@@ -39,7 +39,7 @@ func TestVisionConfigParsing(t *testing.T) {
 					]
 				}
 			}`,
-			wantErr:  false,
+			wantErr: false,
 			validate: func(t *testing.T, cfg *Config) {
 				if cfg.Vision == nil {
 					t.Fatal("expected non-nil Vision")
@@ -85,7 +85,7 @@ func TestVisionConfigParsing(t *testing.T) {
 					]
 				}
 			}`,
-			wantErr:  false,
+			wantErr: false,
 			validate: func(t *testing.T, cfg *Config) {
 				if cfg.Vision == nil {
 					t.Fatal("expected non-nil Vision")
@@ -126,7 +126,7 @@ func TestVisionConfigParsing(t *testing.T) {
 					]
 				}
 			}`,
-			wantErr:  false,
+			wantErr: false,
 			validate: func(t *testing.T, cfg *Config) {
 				providers := cfg.Vision.Providers
 				if providers[0].DefaultTimeout() != 20 {
@@ -165,22 +165,31 @@ func TestDefaultConfigHasNilVision(t *testing.T) {
 }
 
 func TestConfigPath(t *testing.T) {
-	tests := []struct {
+	type testConfigPath struct {
 		name      string
 		xdgConfig string
 		home      string
 		want      string
-	}{
+	}
+
+	tests := []testConfigPath{
 		{
 			name:      "XDG_CONFIG_HOME set",
 			xdgConfig: "/custom/config",
-			want:       "/custom/config/screenshooter-mcp/config.json",
+			want:      "/custom/config/screenshooter-mcp/config.json",
 		},
-		{
+	}
+
+	// the GitHub CI environment prevent us to set HOME, so we have to use
+	// the real HOME value provided by the environment. If there is none,
+	// then this test cannot run.
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		tests = append(tests, testConfigPath{
 			name: "use home directory",
-			home: "/home/testuser",
-			want: "/home/testuser/.config/screenshooter-mcp/config.json",
-		},
+			home: home,
+			want: home + "/.config/screenshooter-mcp/config.json",
+		})
 	}
 
 	for _, tt := range tests {
@@ -188,10 +197,6 @@ func TestConfigPath(t *testing.T) {
 			if tt.xdgConfig != "" {
 				t.Setenv("XDG_CONFIG_HOME", tt.xdgConfig)
 			}
-			if tt.home != "" {
-				t.Setenv("HOME", tt.home)
-			}
-
 			cfg := &Config{}
 			got := cfg.Path()
 			if got != tt.want {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -15,7 +17,7 @@ func TestVisionConfigParsing(t *testing.T) {
 		{
 			name:    "empty config",
 			json:    `{}`,
-			wantErr: false,
+			wantErr:  false,
 			validate: func(t *testing.T, cfg *Config) {
 				if cfg.Vision != nil {
 					t.Error("expected nil Vision for empty config")
@@ -37,7 +39,7 @@ func TestVisionConfigParsing(t *testing.T) {
 					]
 				}
 			}`,
-			wantErr: false,
+			wantErr:  false,
 			validate: func(t *testing.T, cfg *Config) {
 				if cfg.Vision == nil {
 					t.Fatal("expected non-nil Vision")
@@ -83,7 +85,7 @@ func TestVisionConfigParsing(t *testing.T) {
 					]
 				}
 			}`,
-			wantErr: false,
+			wantErr:  false,
 			validate: func(t *testing.T, cfg *Config) {
 				if cfg.Vision == nil {
 					t.Fatal("expected non-nil Vision")
@@ -124,7 +126,7 @@ func TestVisionConfigParsing(t *testing.T) {
 					]
 				}
 			}`,
-			wantErr: false,
+			wantErr:  false,
 			validate: func(t *testing.T, cfg *Config) {
 				providers := cfg.Vision.Providers
 				if providers[0].DefaultTimeout() != 20 {
@@ -159,5 +161,209 @@ func TestDefaultConfigHasNilVision(t *testing.T) {
 	cfg := DefaultConfig()
 	if cfg.Vision != nil {
 		t.Error("DefaultConfig() should have nil Vision")
+	}
+}
+
+func TestConfigPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		xdgConfig string
+		home      string
+		want      string
+	}{
+		{
+			name:      "XDG_CONFIG_HOME set",
+			xdgConfig: "/custom/config",
+			want:       "/custom/config/screenshooter-mcp/config.json",
+		},
+		{
+			name: "use home directory",
+			home: "/home/testuser",
+			want: "/home/testuser/.config/screenshooter-mcp/config.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.xdgConfig != "" {
+				t.Setenv("XDG_CONFIG_HOME", tt.xdgConfig)
+			}
+			if tt.home != "" {
+				t.Setenv("HOME", tt.home)
+			}
+
+			cfg := &Config{}
+			got := cfg.Path()
+			if got != tt.want {
+				t.Errorf("Config.Path() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadFromEnv(t *testing.T) {
+	// Create a temp config file
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test-config.json")
+	configData := `{"log_level": "debug", "listen": "127.0.0.1:9999"}`
+	err := os.WriteFile(configPath, []byte(configData), 0644)
+	if err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	t.Setenv("SCREENSHOOTER_CONFIG", configPath)
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load() with env var error = %v", err)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("Load() LogLevel = %v, want 'debug'", cfg.LogLevel)
+	}
+	if cfg.Listen != "127.0.0.1:9999" {
+		t.Errorf("Load() Listen = %v, want '127.0.0.1:9999'", cfg.Listen)
+	}
+}
+
+func TestLoadFromUserConfig(t *testing.T) {
+	// Create user config directory and file
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".config", "screenshooter-mcp")
+	err := os.MkdirAll(configDir, 0755)
+	if err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, "config.json")
+	configData := `{"log_level": "warn", "color": "never"}`
+	err = os.WriteFile(configPath, []byte(configData), 0644)
+	if err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	// Temporarily change home directory
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", oldHome)
+	// Clear XDG_CONFIG_HOME to force using HOME
+	oldXdg := os.Getenv("XDG_CONFIG_HOME")
+	os.Unsetenv("XDG_CONFIG_HOME")
+	defer os.Setenv("XDG_CONFIG_HOME", oldXdg)
+	// Clear SCREENSHOOTER_CONFIG
+	oldConfig := os.Getenv("SCREENSHOOTER_CONFIG")
+	os.Unsetenv("SCREENSHOOTER_CONFIG")
+	defer os.Setenv("SCREENSHOOTER_CONFIG", oldConfig)
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load() with user config error = %v", err)
+	}
+	if cfg.LogLevel != "warn" {
+		t.Errorf("Load() LogLevel = %v, want 'warn'", cfg.LogLevel)
+	}
+	if cfg.Color != "never" {
+		t.Errorf("Load() Color = %v, want 'never'", cfg.Color)
+	}
+}
+
+func TestLoadNoConfig(t *testing.T) {
+	// Ensure no config files exist
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "empty"))
+	t.Setenv("HOME", filepath.Join(tmpDir, "empty-home"))
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load() with no config error = %v", err)
+	}
+	// Should return DefaultConfig
+	if cfg.LogLevel != "info" {
+		t.Errorf("Load() LogLevel = %v, want 'info'", cfg.LogLevel)
+	}
+	if cfg.Color != "auto" {
+		t.Errorf("Load() Color = %v, want 'auto'", cfg.Color)
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	cfg := &Config{
+		LogLevel: "error",
+		Color:    "always",
+		Listen:   "0.0.0.0:11777",
+	}
+
+	err := cfg.Save(configPath)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Load the saved config
+	loaded, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() after Save() error = %v", err)
+	}
+
+	if loaded.LogLevel != "error" {
+		t.Errorf("loaded LogLevel = %v, want 'error'", loaded.LogLevel)
+	}
+	if loaded.Color != "always" {
+		t.Errorf("loaded Color = %v, want 'always'", loaded.Color)
+	}
+	if loaded.Listen != "0.0.0.0:11777" {
+		t.Errorf("loaded Listen = %v, want '0.0.0.0:11777'", loaded.Listen)
+	}
+}
+
+func TestLoadFromInvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "invalid.json")
+	err := os.WriteFile(configPath, []byte("not valid json"), 0644)
+	if err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_, err = Load(configPath)
+	if err == nil {
+		t.Error("Load() with invalid JSON should return error")
+	}
+}
+
+func TestLoadWithExplicitPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "explicit.json")
+	configData := `{"log_level": "error", "color": "always"}`
+	err := os.WriteFile(configPath, []byte(configData), 0644)
+	if err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() with explicit path error = %v", err)
+	}
+	if cfg.LogLevel != "error" {
+		t.Errorf("Load() LogLevel = %v, want 'error'", cfg.LogLevel)
+	}
+}
+
+func TestSaveCreatesDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "subdir1", "subdir2", "config.json")
+
+	cfg := &Config{
+		LogLevel: "info",
+	}
+
+	err := cfg.Save(configPath)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("Save() should create directories and file")
 	}
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,156 @@
+package logging
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestInit(t *testing.T) {
+	tests := []struct {
+		name  string
+		level string
+		color string
+	}{
+		{"debug level", "debug", "never"},
+		{"info level", "info", "never"},
+		{"warn level", "warn", "never"},
+		{"error level", "error", "never"},
+		{"default level", "invalid", "never"},
+		{"color always", "info", "always"},
+		{"color never", "info", "never"},
+		{"color auto", "info", "auto"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Should not panic
+			Init(tt.level, tt.color)
+		})
+	}
+}
+
+func TestLogger(t *testing.T) {
+	Init("info", "never")
+
+	logger := Logger()
+	if logger == nil {
+		t.Error("Logger() returned nil")
+	}
+}
+
+func TestLoggingOutput(t *testing.T) {
+	// Capture output
+	var buf bytes.Buffer
+
+	// Temporarily replace stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Init("info", "never")
+	Info().Str("key", "value").Msg("test message")
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	// Read captured output
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if !strings.Contains(output, "test message") {
+		t.Errorf("expected log output to contain 'test message', got: %s", output)
+	}
+	if !strings.Contains(output, "info") {
+		t.Errorf("expected log output to contain 'info' level, got: %s", output)
+	}
+}
+
+func TestDebugLogging(t *testing.T) {
+	var buf bytes.Buffer
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Init("debug", "never")
+	Debug().Msg("debug message")
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if !strings.Contains(output, "debug message") {
+		t.Errorf("expected log output to contain 'debug message', got: %s", output)
+	}
+}
+
+func TestWarnLogging(t *testing.T) {
+	var buf bytes.Buffer
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Init("warn", "never")
+	Warn().Msg("warn message")
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if !strings.Contains(output, "warn message") {
+		t.Errorf("expected log output to contain 'warn message', got: %s", output)
+	}
+}
+
+func TestErrorLogging(t *testing.T) {
+	var buf bytes.Buffer
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Init("error", "never")
+	Error().Err(nil).Msg("error message")
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if !strings.Contains(output, "error message") {
+		t.Errorf("expected log output to contain 'error message', got: %s", output)
+	}
+}
+
+func TestInfoLevelFiltersDebug(t *testing.T) {
+	var buf bytes.Buffer
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Init("info", "never")
+	Debug().Msg("should not appear")
+	Info().Msg("should appear")
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if strings.Contains(output, "should not appear") {
+		t.Error("debug message should not appear at info level")
+	}
+	if !strings.Contains(output, "should appear") {
+		t.Error("info message should appear at info level")
+	}
+}

--- a/internal/tools/pipeline_test.go
+++ b/internal/tools/pipeline_test.go
@@ -1,0 +1,356 @@
+package tools
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	"github.com/emmanuel-deloget/screenshooter-mcp/internal/vision"
+)
+
+// mockProvider implements vision.Provider for testing
+type mockProvider struct {
+	name     string
+	model    string
+	analyze  func(ctx context.Context, image []byte, prompt string) (string, error)
+	compare  func(ctx context.Context, image1 []byte, image2 []byte, prompt string) (string, error)
+}
+
+func (m *mockProvider) Name() string {
+	return m.name
+}
+
+func (m *mockProvider) ModelName() string {
+	return m.model
+}
+
+func (m *mockProvider) Analyze(ctx context.Context, image []byte, prompt string) (string, error) {
+	if m.analyze != nil {
+		return m.analyze(ctx, image, prompt)
+	}
+	return "mock response", nil
+}
+
+func (m *mockProvider) CompareImages(ctx context.Context, image1 []byte, image2 []byte, prompt string) (string, error) {
+	if m.compare != nil {
+		return m.compare(ctx, image1, image2, prompt)
+	}
+	return "mock comparison", nil
+}
+
+func newMockVisionManager(providers ...*mockProvider) *vision.Manager {
+	m := &vision.Manager{}
+	// Use the same approach as vision_test.go
+	return m
+}
+
+func TestExecutePipeline(t *testing.T) {
+	img := createTestImage(100, 100)
+
+	tests := []struct {
+		name     string
+		steps    []PipelineStep
+		tools    *Tools
+		wantImg  bool
+		wantText bool
+		wantErr  bool
+	}{
+		{
+			name: "capture screen and return image",
+			steps: []PipelineStep{
+				{Tool: "capture_screen", Parameters: map[string]any{}},
+			},
+			tools: &Tools{
+				capture: &mockCapture{
+					images: map[string]image.Image{"": img},
+				},
+			},
+			wantImg:  true,
+			wantText: false,
+			wantErr:  false,
+		},
+		{
+			name: "capture window and return image",
+			steps: []PipelineStep{
+				{Tool: "capture_window", Parameters: map[string]any{"title": "Terminal"}},
+			},
+			tools: &Tools{
+				capture: &mockCapture{
+					images: map[string]image.Image{"window:Terminal": img},
+				},
+			},
+			wantImg:  true,
+			wantText: false,
+			wantErr:  false,
+		},
+		{
+			name: "capture region with explicit coords",
+			steps: []PipelineStep{
+				{Tool: "capture_region", Parameters: map[string]any{
+					"x":      float64(0),
+					"y":      float64(0),
+					"width":  float64(100),
+					"height": float64(100),
+				}},
+			},
+			tools: &Tools{
+				capture: &mockCapture{
+					images: map[string]image.Image{"region": img},
+				},
+			},
+			wantImg:  true,
+			wantText: false,
+			wantErr:  false,
+		},
+		{
+			name: "unknown tool",
+			steps: []PipelineStep{
+				{Tool: "invalid_tool", Parameters: map[string]any{}},
+			},
+			tools:   NewTools(&mockCapture{}),
+			wantErr: true,
+		},
+		{
+			name:    "empty pipeline",
+			steps:   []PipelineStep{},
+			tools:   NewTools(&mockCapture{}),
+			wantErr: true,
+		},
+		{
+			name: "wait_for step",
+			steps: []PipelineStep{
+				{Tool: "wait_for", Parameters: map[string]any{"seconds": float64(0)}},
+				{Tool: "capture_screen", Parameters: map[string]any{}},
+			},
+			tools: &Tools{
+				capture: &mockCapture{
+					images: map[string]image.Image{"": img},
+				},
+			},
+			wantImg:  true,
+			wantText: false,
+			wantErr:  false,
+		},
+		{
+			name: "wait_for invalid seconds too high",
+			steps: []PipelineStep{
+				{Tool: "wait_for", Parameters: map[string]any{"seconds": float64(31)}},
+			},
+			tools:   NewTools(&mockCapture{}),
+			wantErr: true,
+		},
+		{
+			name: "wait_for negative seconds",
+			steps: []PipelineStep{
+				{Tool: "wait_for", Parameters: map[string]any{"seconds": float64(-1)}},
+			},
+			tools:   NewTools(&mockCapture{}),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imgBase64, text, err := ExecutePipeline(context.Background(), tt.steps, tt.tools)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExecutePipeline() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if tt.wantImg && imgBase64 == "" {
+					t.Error("ExecutePipeline() expected image output, got empty")
+				}
+				if tt.wantText && text == "" {
+					t.Error("ExecutePipeline() expected text output, got empty")
+				}
+				if !tt.wantImg && imgBase64 != "" {
+					t.Error("ExecutePipeline() unexpected image output")
+				}
+				if !tt.wantText && text != "" {
+					t.Error("ExecutePipeline() unexpected text output")
+				}
+			}
+		})
+	}
+}
+
+func TestPipelineStack(t *testing.T) {
+	t.Run("push and pop", func(t *testing.T) {
+		stack := &pipelineStack{}
+		stack.push("test")
+		item, err := stack.pop()
+		if err != nil {
+			t.Errorf("pop() unexpected error = %v", err)
+		}
+		if item != "test" {
+			t.Errorf("pop() = %v, want %v", item, "test")
+		}
+	})
+
+	t.Run("pop empty stack", func(t *testing.T) {
+		stack := &pipelineStack{}
+		_, err := stack.pop()
+		if err == nil {
+			t.Error("pop() on empty stack should return error")
+		}
+	})
+
+	t.Run("popImage with valid image", func(t *testing.T) {
+		stack := &pipelineStack{}
+		imgData := []byte("imagedata")
+		stack.push(imgData)
+		result, err := stack.popImage()
+		if err != nil {
+			t.Errorf("popImage() unexpected error = %v", err)
+		}
+		if string(result) != "imagedata" {
+			t.Errorf("popImage() = %v, want %v", string(result), "imagedata")
+		}
+	})
+
+	t.Run("popImage with invalid type", func(t *testing.T) {
+		stack := &pipelineStack{}
+		stack.push("not an image")
+		_, err := stack.popImage()
+		if err == nil {
+			t.Error("popImage() with invalid type should return error")
+		}
+	})
+
+	t.Run("popImage empty stack", func(t *testing.T) {
+		stack := &pipelineStack{}
+		_, err := stack.popImage()
+		if err == nil {
+			t.Error("popImage() on empty stack should return error")
+		}
+	})
+
+	t.Run("popRegion from map", func(t *testing.T) {
+		stack := &pipelineStack{}
+		stack.push(map[string]any{
+			"x":      float64(10),
+			"y":      float64(20),
+			"width":  float64(100),
+			"height": float64(200),
+		})
+		x, y, w, h, err := stack.popRegion()
+		if err != nil {
+			t.Errorf("popRegion() unexpected error = %v", err)
+		}
+		if x != 10 || y != 20 || w != 100 || h != 200 {
+			t.Errorf("popRegion() = (%v, %v, %v, %v), want (10, 20, 100, 200)", x, y, w, h)
+		}
+	})
+
+	t.Run("popRegion invalid type", func(t *testing.T) {
+		stack := &pipelineStack{}
+		stack.push(12345)
+		_, _, _, _, err := stack.popRegion()
+		if err == nil {
+			t.Error("popRegion() with invalid type should return error")
+		}
+	})
+
+	t.Run("popRegion empty stack", func(t *testing.T) {
+		stack := &pipelineStack{}
+		_, _, _, _, err := stack.popRegion()
+		if err == nil {
+			t.Error("popRegion() on empty stack should return error")
+		}
+	})
+}
+
+func TestExecCaptureRegionFromStack(t *testing.T) {
+	img := createTestImage(100, 100)
+
+	tools := &Tools{
+		capture: &mockCapture{
+			images: map[string]image.Image{"region": img},
+		},
+	}
+	stack := &pipelineStack{}
+
+	// Push a region onto the stack
+	stack.push(map[string]any{
+		"x":      float64(0),
+		"y":      float64(0),
+		"width":  float64(50),
+		"height": float64(50),
+	})
+
+	err := execCaptureRegion(context.Background(), map[string]any{}, tools, stack)
+	if err != nil {
+		t.Errorf("execCaptureRegion() from stack error = %v", err)
+	}
+
+	// Stack should have an image now
+	if len(stack.items) != 1 {
+		t.Errorf("execCaptureRegion() should push 1 item, got %v", len(stack.items))
+	}
+}
+
+func TestExecFindRegionMissingImage(t *testing.T) {
+	tools := &Tools{}
+	stack := &pipelineStack{}
+
+	err := execFindRegion(context.Background(), map[string]any{"description": "test"}, tools, stack)
+	if err == nil {
+		t.Error("execFindRegion() with empty stack should return error")
+	}
+}
+
+func TestExecExtractTextMissingImage(t *testing.T) {
+	tools := &Tools{}
+	stack := &pipelineStack{}
+
+	err := execExtractText(context.Background(), map[string]any{}, tools, stack)
+	if err == nil {
+		t.Error("execExtractText() with empty stack should return error")
+	}
+}
+
+func TestExecAnalyzeImageMissingPrompt(t *testing.T) {
+	tools := &Tools{}
+	stack := &pipelineStack{}
+	stack.push([]byte("imagedata"))
+
+	err := execAnalyzeImage(context.Background(), map[string]any{}, tools, stack)
+	if err == nil {
+		t.Error("execAnalyzeImage() without prompt should return error")
+	}
+}
+
+func TestExecCompareImagesMissingImages(t *testing.T) {
+	tools := &Tools{}
+	stack := &pipelineStack{}
+
+	// Only push one image
+	stack.push([]byte("image1"))
+
+	err := execCompareImages(context.Background(), map[string]any{}, tools, stack)
+	if err == nil {
+		t.Error("execCompareImages() with only one image should return error")
+	}
+}
+
+func TestExecWaitForInvalidSeconds(t *testing.T) {
+	err := execWaitFor(map[string]any{"seconds": "not_a_number"})
+	if err == nil {
+		t.Error("execWaitFor() with invalid seconds should return error")
+	}
+}
+
+func TestExecutePipelineCaptureRegionMissingCoordsAndStack(t *testing.T) {
+	tools := &Tools{
+		capture: &mockCapture{
+			images: map[string]image.Image{"region": createTestImage(100, 100)},
+		},
+	}
+	stack := &pipelineStack{}
+
+	err := execCaptureRegion(context.Background(), map[string]any{}, tools, stack)
+	if err == nil {
+		t.Error("execCaptureRegion() without coords and empty stack should return error")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -283,6 +283,9 @@ func (t *Tools) CompareImages(ctx context.Context, image1 []byte, image2 []byte,
 //
 // Returns the PNG-encoded data, or an error if encoding fails.
 func encodeImage(img image.Image) ([]byte, error) {
+	if img == nil {
+		return nil, fmt.Errorf("cannot encode nil image")
+	}
 	var buf bytes.Buffer
 	if err := png.Encode(&buf, img); err != nil {
 		return nil, fmt.Errorf("failed to encode image: %w", err)

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1,0 +1,532 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"testing"
+
+	"github.com/emmanuel-deloget/screenshooter-mcp/internal/capture"
+	"github.com/emmanuel-deloget/screenshooter-mcp/internal/vision"
+)
+
+// mockCapture implements capture.ScreenCapture for testing
+type mockCapture struct {
+	monitors []capture.Monitor
+	windows  []capture.Window
+	images   map[string]image.Image
+	err      error
+}
+
+func (m *mockCapture) ListMonitors() ([]capture.Monitor, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.monitors, nil
+}
+
+func (m *mockCapture) ListWindows() ([]capture.Window, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.windows, nil
+}
+
+func (m *mockCapture) CaptureScreen(monitor string) (image.Image, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if img, ok := m.images[monitor]; ok {
+		return img, nil
+	}
+	if monitor == "" {
+		if img, ok := m.images["all"]; ok {
+			return img, nil
+		}
+	}
+	return nil, fmt.Errorf("monitor not found: %s", monitor)
+}
+
+func (m *mockCapture) CaptureWindow(title string) (image.Image, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if img, ok := m.images["window:"+title]; ok {
+		return img, nil
+	}
+	return nil, fmt.Errorf("window not found: %s", title)
+}
+
+func (m *mockCapture) CaptureRegion(x, y, w, h int) (image.Image, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	key := "region"
+	if img, ok := m.images[key]; ok {
+		return img, nil
+	}
+	return image.NewRGBA(image.Rect(0, 0, w, h)), nil
+}
+
+func (m *mockCapture) CaptureAllScreens() (image.Image, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if img, ok := m.images["all"]; ok {
+		return img, nil
+	}
+	return nil, fmt.Errorf("capture failed")
+}
+
+func createTestImage(width, height int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for i := range img.Pix {
+		img.Pix[i] = 0xFF
+	}
+	return img
+}
+
+// mockVisionManager wraps *vision.Manager to allow testing
+type mockVisionManager struct {
+	mgr *vision.Manager
+}
+
+func (m *mockVisionManager) Providers() []vision.ProviderInfo {
+	if m.mgr == nil {
+		return nil
+	}
+	return m.mgr.Providers()
+}
+
+func (m *mockVisionManager) AnalyzeWith(ctx context.Context, provider string, image []byte, prompt string) (string, error) {
+	if m.mgr == nil {
+		return "", fmt.Errorf("no vision providers configured")
+	}
+	return m.mgr.AnalyzeWith(ctx, provider, image, prompt)
+}
+
+func (m *mockVisionManager) CompareImages(ctx context.Context, provider string, image1, image2 []byte, prompt string) (string, error) {
+	if m.mgr == nil {
+		return "", fmt.Errorf("no vision providers configured")
+	}
+	return m.mgr.CompareImages(ctx, provider, image1, image2, prompt)
+}
+
+func TestSetVisionManager(t *testing.T) {
+	tools := NewTools(&mockCapture{})
+	if tools.vision != nil {
+		t.Error("vision manager should be nil initially")
+	}
+
+	mgr := &vision.Manager{}
+	tools.SetVisionManager(mgr)
+
+	if tools.vision != mgr {
+		t.Error("SetVisionManager() did not set the vision manager")
+	}
+}
+
+func TestListVisionProvidersWithManager(t *testing.T) {
+	tools := NewTools(&mockCapture{})
+	tools.SetVisionManager(&vision.Manager{})
+
+	providers, err := tools.ListVisionProviders(context.Background())
+	if err != nil {
+		t.Errorf("ListVisionProviders() with manager error = %v", err)
+	}
+	// Empty manager returns empty slice, not nil
+	if len(providers) != 0 {
+		t.Errorf("ListVisionProviders() should return empty slice for empty manager, got %v", providers)
+	}
+}
+
+func TestAnalyzeImage(t *testing.T) {
+	tools := NewTools(&mockCapture{})
+	tools.SetVisionManager(&vision.Manager{})
+
+	_, err := tools.AnalyzeImage(context.Background(), []byte("imagedata"), "prompt", "", 0)
+	if err == nil {
+		t.Error("AnalyzeImage() should fail with empty manager")
+	}
+}
+
+func TestExtractText(t *testing.T) {
+	tools := NewTools(&mockCapture{})
+	tools.SetVisionManager(&vision.Manager{})
+
+	_, err := tools.ExtractText(context.Background(), []byte("imagedata"), "", 0)
+	if err == nil {
+		t.Error("ExtractText() should fail with empty manager")
+	}
+}
+
+func TestFindRegion(t *testing.T) {
+	tools := NewTools(&mockCapture{})
+	tools.SetVisionManager(&vision.Manager{})
+
+	_, err := tools.FindRegion(context.Background(), []byte("imagedata"), "description", "", 0)
+	if err == nil {
+		t.Error("FindRegion() should fail with empty manager")
+	}
+}
+
+func TestCompareImages(t *testing.T) {
+	tools := NewTools(&mockCapture{})
+	tools.SetVisionManager(&vision.Manager{})
+
+	_, err := tools.CompareImages(context.Background(), []byte("image1"), []byte("image2"), "", "", 0)
+	if err == nil {
+		t.Error("CompareImages() should fail with empty manager")
+	}
+}
+
+func TestListMonitors(t *testing.T) {
+	tests := []struct {
+		name     string
+		mock     *mockCapture
+		wantLen  int
+		wantErr  bool
+	}{
+		{
+			name: "success with monitors",
+			mock: &mockCapture{
+				monitors: []capture.Monitor{
+					{Name: "DP-1", Aliases: []string{"1"}, X: 0, Y: 0, Width: 1920, Height: 1080},
+					{Name: "DP-2", Aliases: []string{"2"}, X: 1920, Y: 0, Width: 1920, Height: 1080},
+				},
+			},
+			wantLen: 2,
+			wantErr: false,
+		},
+		{
+			name: "success with no monitors",
+			mock: &mockCapture{
+				monitors: []capture.Monitor{},
+			},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name: "error from capture backend",
+			mock: &mockCapture{
+				err: fmt.Errorf("capture failed"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tools := NewTools(tt.mock)
+			monitors, err := tools.ListMonitors(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ListMonitors() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(monitors) != tt.wantLen {
+				t.Errorf("ListMonitors() got %v monitors, want %v", len(monitors), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestListWindows(t *testing.T) {
+	tests := []struct {
+		name     string
+		mock     *mockCapture
+		wantLen  int
+		wantErr  bool
+	}{
+		{
+			name: "success with windows",
+			mock: &mockCapture{
+				windows: []capture.Window{
+					{ID: 1, Name: "Terminal", X: 0, Y: 0, Width: 800, Height: 600, Active: true},
+					{ID: 2, Name: "Firefox", X: 100, Y: 100, Width: 1200, Height: 800},
+				},
+			},
+			wantLen: 2,
+			wantErr: false,
+		},
+		{
+			name: "success with no windows",
+			mock: &mockCapture{
+				windows: []capture.Window{},
+			},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name: "error from capture backend",
+			mock: &mockCapture{
+				err: fmt.Errorf("capture failed"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tools := NewTools(tt.mock)
+			windows, err := tools.ListWindows(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ListWindows() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(windows) != tt.wantLen {
+				t.Errorf("ListWindows() got %v windows, want %v", len(windows), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCaptureScreen(t *testing.T) {
+	img := createTestImage(100, 100)
+
+	tests := []struct {
+		name     string
+		monitor  string
+		mock     *mockCapture
+		wantErr  bool
+	}{
+		{
+			name:    "capture specific monitor",
+			monitor: "DP-1",
+			mock: &mockCapture{
+				images: map[string]image.Image{"DP-1": img},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "capture all screens",
+			monitor: "",
+			mock: &mockCapture{
+				images: map[string]image.Image{"all": img},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "monitor not found",
+			monitor: "nonexistent",
+			mock:    &mockCapture{},
+			wantErr: true,
+		},
+		{
+			name:    "error from capture backend",
+			monitor: "DP-1",
+			mock: &mockCapture{
+				err: fmt.Errorf("capture failed"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tools := NewTools(tt.mock)
+			data, err := tools.CaptureScreen(context.Background(), tt.monitor)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CaptureScreen() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && data == nil {
+				t.Error("CaptureScreen() returned nil data without error")
+			}
+		})
+	}
+}
+
+func TestCaptureWindow(t *testing.T) {
+	img := createTestImage(100, 100)
+
+	tests := []struct {
+		name    string
+		title   string
+		mock    *mockCapture
+		wantErr bool
+	}{
+		{
+			name:  "capture existing window",
+			title: "Terminal",
+			mock: &mockCapture{
+				images: map[string]image.Image{"window:Terminal": img},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "window not found",
+			title: "Nonexistent",
+			mock:  &mockCapture{},
+			wantErr: true,
+		},
+		{
+			name:  "error from capture backend",
+			title: "Terminal",
+			mock: &mockCapture{
+				err: fmt.Errorf("capture failed"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tools := NewTools(tt.mock)
+			_, err := tools.CaptureWindow(context.Background(), tt.title)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CaptureWindow() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCaptureRegion(t *testing.T) {
+	img := createTestImage(100, 100)
+
+	tests := []struct {
+		name    string
+		x, y    int
+		w, h    int
+		mock    *mockCapture
+		wantErr bool
+	}{
+		{
+			name: "capture valid region",
+			x:    0,
+			y:    0,
+			w:    100,
+			h:    100,
+			mock: &mockCapture{
+				images: map[string]image.Image{"region": img},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error from capture backend",
+			x:    0,
+			y:    0,
+			w:    100,
+			h:    100,
+			mock: &mockCapture{
+				err: fmt.Errorf("capture failed"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tools := NewTools(tt.mock)
+			data, err := tools.CaptureRegion(context.Background(), tt.x, tt.y, tt.w, tt.h)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CaptureRegion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && data == nil {
+				t.Error("CaptureRegion() returned nil data without error")
+			}
+		})
+	}
+}
+
+func TestEncodeImage(t *testing.T) {
+	tests := []struct {
+		name    string
+		img     image.Image
+		wantErr bool
+	}{
+		{
+			name:    "valid image",
+			img:     image.NewRGBA(image.Rect(0, 0, 10, 10)),
+			wantErr: false,
+		},
+		{
+			name:    "nil image",
+			img:     nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := encodeImage(tt.img)
+
+			if tt.img == nil {
+				if err == nil {
+					t.Error("encodeImage(nil) should return error")
+				}
+				return
+			}
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("encodeImage() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && len(data) == 0 {
+				t.Error("encodeImage() returned empty data")
+			}
+		})
+	}
+}
+
+func TestGetSkillInfo(t *testing.T) {
+	tools := NewTools(&mockCapture{})
+	info := tools.GetSkillInfo()
+
+	if info == "" {
+		t.Error("GetSkillInfo() returned empty string")
+	}
+}
+
+func TestSuccessResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    interface{}
+		wantErr bool
+	}{
+		{
+			name:    "string data",
+			data:    "test result",
+			wantErr: false,
+		},
+		{
+			name:    "struct data",
+			data:    map[string]string{"key": "value"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := SuccessResult(tt.data)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SuccessResult() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if !result.Success {
+					t.Error("SuccessResult() Success should be true")
+				}
+				if len(result.Data) == 0 {
+					t.Error("SuccessResult() Data should not be empty")
+				}
+			}
+		})
+	}
+}
+
+func TestErrorResult(t *testing.T) {
+	errMsg := "test error"
+	result := ErrorResult(errMsg)
+
+	if result.Success {
+		t.Error("ErrorResult() Success should be false")
+	}
+	if result.Error != errMsg {
+		t.Errorf("ErrorResult() Error = %v, want %v", result.Error, errMsg)
+	}
+}


### PR DESCRIPTION
This PR improves unit test coverage. 

We went from:

| state | directory                    | coverage |
|-------|------------------------------|----------|
| ok    | cmd/screenshooter-mcp-server | 19.1%    |
| ok    | internal/capture             | 39.7%    |
|       | internal/capture/wayland     | 0.0%     |
|       | internal/capture/x11         | 0.0%     |
| ok    | internal/config              | 8.3%     |
|       | internal/logging             | 0.0%     |
|       | internal/tools               | 0.0%     |
| ok    | internal/vision              | 55.8%    |

To:

| state | directory                    | coverage |
|-------|------------------------------|----------|
| ok    | cmd/screenshooter-mcp-server | 19.1%    |
| ok    | internal/capture             | 60.3%    |
|       | internal/capture/wayland     | 0.0%     |
|       | internal/capture/x11         | 0.0%     |
| ok    | internal/config              | 83.3%    |
| ok    | internal/logging             | 100.0%   |
| ok    | internal/tools               | 64.4%    |
| ok    | internal/vision              | 55.8%    |

