### PR TITLE
go: update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/jezek/xgb v1.3.1
 	github.com/mattn/go-isatty v0.0.22
 	github.com/modelcontextprotocol/go-sdk v1.6.0
-	github.com/nskaggs/perfuncted v0.2.5
+	github.com/nskaggs/perfuncted v0.3.2
 	github.com/rs/zerolog v1.35.1
 	github.com/sashabaranov/go-openai v1.41.2
 	google.golang.org/genai v1.56.0
@@ -37,7 +37,7 @@ require (
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260508151727-1282bb917829 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
 github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
-github.com/nskaggs/perfuncted v0.2.5 h1:IXfwgmT1qIKNaCSOg2Ogy556OjQ/jTGSjMAzDjxvhvE=
-github.com/nskaggs/perfuncted v0.2.5/go.mod h1:bxZ7vF0F7G2Kab00dNZAbxRfzAhYGWejiIg2SL+fsr4=
+github.com/nskaggs/perfuncted v0.3.2 h1:XTZNGYm2HR0SUNdyZsKLe3AsONgEBjYV2wOtg0p7l7U=
+github.com/nskaggs/perfuncted v0.3.2/go.mod h1:bxZ7vF0F7G2Kab00dNZAbxRfzAhYGWejiIg2SL+fsr4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -80,8 +80,8 @@ github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260508151727-1
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
-github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
+github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/match v1.2.0 h1:0pt8FlkOwjN2fPt4bIl4BoNxb98gGHN2ObFEDkrfZnM=
 github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=

--- a/internal/capture/wayland/gnome.go
+++ b/internal/capture/wayland/gnome.go
@@ -20,6 +20,10 @@ type GnomeManager struct {
 	obj  dbus.BusObject
 }
 
+var (
+	errNotImplemented = fmt.Errorf("this feature is not implemented")
+)
+
 func NewGnomeManager() (*GnomeManager, error) {
 	conn, err := dbus.SessionBus()
 	if err != nil {
@@ -84,6 +88,14 @@ func (g *GnomeManager) Move(ctx context.Context, title string, x, y int) error {
 
 func (g *GnomeManager) Resize(ctx context.Context, title string, w, h int) error {
 	return g.obj.CallWithContext(ctx, gnomeExtIface+".Resize", 0, title, int32(w), int32(h)).Err
+}
+
+func (g *GnomeManager) Fullscreen(ctx context.Context, title string) error {
+	return errNotImplemented
+}
+
+func (g *GnomeManager) Unfullscreen(ctx context.Context, title string) error {
+	return errNotImplemented
 }
 
 func (g *GnomeManager) ActiveTitle(ctx context.Context) (string, error) {


### PR DESCRIPTION
nskaggs/perfuncted added two methods in the window.Manager interface, but these functions are not used in the current instance of our code, so we can safely announce that they are not implemented. An implementation would require changed in the Gnome shell extension.
